### PR TITLE
Update the build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 _site
 .sass-cache
 .jekyll-metadata
+.ruby-version
+.bundle
+vendor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       sass (~> 3.4)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
-    kramdown (1.11.1)
+    kramdown (1.12.0)
     liquid (3.0.6)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
-This is the source for "FOLIO Developers" at folio.indexdata.com
+This is the source for "FOLIO Developers" at folio-org.github.io
 
-```$ bundle install```
+Local development requires [Jekyll](http://jekyllrb.com/) and [Bundler](http://bundler.io/).
 
-```$ jekyll serve --port 5000```
+For Ruby, using [rbenv](https://github.com/rbenv/rbenv) and its 'ruby-build' plugin ensures a smooth process. In this directory, set the ruby version with: `rbenv local ...` 
 
-If need to override any more files, then copy them from the theme.
+`$ bundle install --path vendor/bundle`
+
+`$ bundle exec jekyll serve --port 5000`
+
+`$ bundle exec jekyll build`
+
+Occasionally do `bundle update` to advance the versions of dependencies.
+
+If there is a need to override any more files, then copy them from the theme.
 To find them, do: `bundle show minima`

--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,8 @@ url: "https://folio.indexdata.com" # the base hostname & protocol for your site
 markdown: kramdown
 theme: minima
 
+exclude: [Gemfile, Gemfile.lock, CONTRIBUTING.md, README.md, vendor]
+
 collections:
   posts:
     permalink: /news/:year/:month/:day/:title/


### PR DESCRIPTION
Ready to merge.

The README now refers to ‘bundle exec …’ and mentions rbenv.

Exclude files that should not be deployed.