### PR TITLE
Link to slack

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -21,12 +21,11 @@ Source code is on GitHub: [https://github.com/folio-org](https://github.com/foli
 The FOLIO developer community consists of:
 
 * Several software engineering teams with commit access to specific
-  platform components, such as Okapi
-* Contributors from the community
+  platform components, such as Okapi.
+* Contributors from the community.
 
 Team members can be contacted via
-[Slack](https://su17s9g5c5.execute-api.us-east-1.amazonaws.com/production)
-or the [discussion site](https://discuss.folio.org).
+Slack or the discussion site.
 
 ## Contributing
 
@@ -34,7 +33,5 @@ There are many ways to contribute to FOLIO development:
 
 * Contributing directly to the software development.  (See the
   [Guidelines for Contributing Code](contrib-code.html).)
-* Engaging with the [issue tracker](https://issues.folio.org/).
-* Joining the conversation on
-  [Slack](https://su17s9g5c5.execute-api.us-east-1.amazonaws.com/production)
-  or the [discussion site](https://discuss.folio.org).
+* Engaging with the issue tracker.
+* Joining the conversation on Slack or the discussion site.

--- a/community/index.md
+++ b/community/index.md
@@ -8,8 +8,11 @@ title: FOLIO Community
 The discussion area and mailing lists for the FOLIO project are located at:
 [https://discuss.folio.org](https://discuss.folio.org)
 
+Real-time chat is via Slack at
+[https://folio-project.slack.com](https://folio-project.slack.com)
+(join [here](https://su17s9g5c5.execute-api.us-east-1.amazonaws.com/production) first).
 
-The issue/bug tracking system is at: [https://issues.folio.org/](https://issues.folio.org/)
+The issue/bug tracking system is at: [https://issues.folio.org](https://issues.folio.org)
 
 Source code is on GitHub: [https://github.com/folio-org](https://github.com/folio-org)
 


### PR DESCRIPTION
Provide direct link to Slack, and to the join page,in the top section.
Remove extra links.