### PR TITLE
FOLIO-293 which forum, FOLIO-298 guide issues

### DIFF
--- a/community/guide-issues.md
+++ b/community/guide-issues.md
@@ -1,0 +1,95 @@
+---
+layout: page
+title: Guidelines for FOLIO issue tracker
+---
+
+[https://issues.folio.org](https://issues.folio.org)
+
+- Specific bugs, problems, feature requests.
+
+- Also tasks that you know need to be done sometime later.
+
+- If not clear whether to add a new issue, then commence a
+  Discuss topic first, and later summarise into an Issue.
+
+- Follow up in other fora for any lengthy discussion.
+  Then summarise into further issue tracker comments.
+  Provide links in both directions.
+
+## Preparing to add an issue
+
+Describe the issue concisely in the Summary and Description fields.
+Use Comments for further detail.
+The Summary and Description are also utilized for reports, so detail is
+better in Comments.
+
+Use the Search facility to ensure that not already reported.
+
+Use a local text file to prepare, then copy-and-paste.
+
+Use attachments for long log files, text listings, and images.
+
+## Create issue
+
+When creating the issue, select the most relevant Project and the Issue
+Type (see below).
+If unsure which Project, then use "FOLIO".
+If unsure which Type, then use "Task".
+Someone can change these later if necessary.
+
+After issue creation, use follow-up Comments for further detail.
+Attachments can be added later.
+
+For the "Bug" issue type, use the "Configure Fields" option to add the
+"Environment" field.
+
+Someone else will later determine the Assignee and the Priority, and will
+Link between relevant issues.
+
+## Issue types
+
+Each Project uses a set of the following types:
+
+- **New Feature**: Explain something new, yet to be developed.
+- **Bug**: A problem which impairs or prevents proper function.
+- **Task**: Something else that needs to be done.
+- **Umbrella**: [TODO: Need to define this.]
+
+## Priority levels
+
+The priority level indicates the importance.
+These are set by someone else.
+
+- **P1**: highest priority item, drop everything else before this is resolved, reserved for critical bugfixes
+- **P2**: normal priority level, must be included in the current development cycle
+- **P3**: low priority level, item will be considered for inclusion in the next dev cycle
+- **P4**: lowest priority level, nice-to have things that require future discussion and design
+
+## Status
+
+We use the following workflow:
+
+- **Open**: Ready for the assignee to commence work on it.
+- **In Progress**: Being actively worked on at the moment by the assignee.
+- **Reopened**: The resolution was incorrect.
+- **Closed**: Finished.
+
+The Status does not preclude other people from assisting.
+Please add relevant Comments.
+
+## Linking
+
+Other people will create tracker Links between relevant issues.
+
+Using an Issue identifier within text Comments will automatically link to
+it, e.g. `FOLIO-298`
+
+Provide other relevant links, for example GitHub pull requests, and
+Discuss topics.
+
+## Filters
+
+Various issue Filters are provided. For example, the "Added recently"
+and "Updated recently" filters help to be aware of recent action.
+
+Create your own filters. Use one as a base, then twiddle and Save As.

--- a/community/guide-issues.md
+++ b/community/guide-issues.md
@@ -5,51 +5,38 @@ title: Guidelines for FOLIO issue tracker
 
 [https://issues.folio.org](https://issues.folio.org)
 
-- Specific bugs, problems, feature requests.
-
-- Also tasks that you know need to be done sometime later.
-
-- If not clear whether to add a new issue, then commence a
-  Discuss topic first, and later summarise into an Issue.
-  See guidelines about [which forum](which-forum) to use.
-
-- Follow up in other fora for any lengthy discussion.
-  Then summarise into further issue tracker comments.
-  Provide links in both directions.
-
 ## Preparing to add an issue
 
-Describe the issue concisely in the Summary and Description fields.
-Use Comments for further detail.
-The Summary and Description are also utilized for reports, so detail is
-better in Comments.
+Describe the issue concisely in the _Summary_ and _Description_ fields.
+Use _Comments_ for further detail.
+The _Summary_ and _Description_ are also utilized for reports, so detail is
+better in _Comments_.
 
-Use the Search facility to ensure that not already reported.
+Use the Search facility to ensure that an issue is not already reported.
 
-Use a local text file to prepare, then copy-and-paste.
+To avoid issues with login timeouts, use a local text file to prepare the summary and description, then copy-and-paste.
 
-Use attachments for long log files, text listings, and images.
+Use attachments for long log files, text listings, and images.  
+Be sure information that would compromise a user's privacy is redacted from log files.
 
 ## Create issue
 
-When creating the issue, select the most relevant Project and the Issue
-Type (see [below](#issue-types)).
+When creating the issue, select the most relevant _Project_ and the _Issue
+Type_ (see [below](#issue-types) for definitions).
 If unsure which Project, then use "FOLIO".
 If unsure which Type, then use "Task".
 Someone can change these later if necessary.
+For the "Bug" issue type, use the "Configure Fields" option to add the _Environment_ field.
 
-After issue creation, use follow-up Comments for further detail.
+After issue creation, use follow-up _Comments_ for further detail.
 Attachments can be added later.
 
-For the "Bug" issue type, use the "Configure Fields" option to add the
-"Environment" field.
-
-Someone else will later determine the Assignee and the Priority, and will
-Link between relevant issues.
+Someone else will later determine the _Assignee_ and the _Priority_, and will
+link between relevant issues.
 
 ## Issue types
 
-Each Project uses a set of the following types:
+Each Project uses the following types:
 
 - **New Feature**: Explain something new, yet to be developed.
 - **Bug**: A problem which impairs or prevents proper function.
@@ -60,7 +47,7 @@ Each Project uses a set of the following types:
 ## Priority levels
 
 The priority level indicates the importance.
-These are set by someone else.
+An issue's priority is set by the project managers.
 
 - **P1**: highest priority item, drop everything else before this is resolved, reserved for critical bugfixes
 - **P2**: normal priority level, must be included in the current development cycle
@@ -76,7 +63,7 @@ We use the following workflow:
 - **Reopened**: The resolution was incorrect.
 - **Closed**: Finished.
 
-The Status does not preclude other people from assisting.
+This Status does not preclude other people from assisting.
 Please add relevant Comments.
 
 ## Linking
@@ -84,9 +71,10 @@ Please add relevant Comments.
 Other people will create tracker Links between relevant issues.
 
 Using an Issue identifier within text Comments will automatically link to
-it, e.g. `FOLIO-298`
+it, e.g. `FOLIO-298`.
+Using an issue identifier in git commit messages will also automatically link to the Issue.
 
-Provide other relevant links, for example GitHub pull requests, and
+Provide other relevant links, for example GitHub pull requests and
 Discuss topics.
 
 ## Filters

--- a/community/guide-issues.md
+++ b/community/guide-issues.md
@@ -33,7 +33,7 @@ Use attachments for long log files, text listings, and images.
 ## Create issue
 
 When creating the issue, select the most relevant Project and the Issue
-Type (see below).
+Type (see [below](#issue-types)).
 If unsure which Project, then use "FOLIO".
 If unsure which Type, then use "Task".
 Someone can change these later if necessary.
@@ -54,7 +54,8 @@ Each Project uses a set of the following types:
 - **New Feature**: Explain something new, yet to be developed.
 - **Bug**: A problem which impairs or prevents proper function.
 - **Task**: Something else that needs to be done.
-- **Umbrella**: [TODO: Need to define this.]
+- **Umbrella**: This type is used for project management.
+  Please use one of the other types.
 
 ## Priority levels
 

--- a/community/guide-issues.md
+++ b/community/guide-issues.md
@@ -11,6 +11,7 @@ title: Guidelines for FOLIO issue tracker
 
 - If not clear whether to add a new issue, then commence a
   Discuss topic first, and later summarise into an Issue.
+  See guidelines about [which forum](which-forum) to use.
 
 - Follow up in other fora for any lengthy discussion.
   Then summarise into further issue tracker comments.

--- a/community/index.md
+++ b/community/index.md
@@ -16,6 +16,8 @@ The issue/bug tracking system is at: [https://issues.folio.org](https://issues.f
 
 Source code is on GitHub: [https://github.com/folio-org](https://github.com/folio-org)
 
+See [guidelines](which-forum) about using each.
+
 ## Developer community
 
 The FOLIO developer community consists of:
@@ -37,10 +39,10 @@ There are many ways to contribute to FOLIO development:
 
 ## Guidelines
 
-* [Guidelines for Contributing Code](contrib-code.html):
+* [Guidelines for Contributing Code](contrib-code):
   GitHub Flow, feature branches, pull requests, version numbers, coding style,
   tests, etc.
 
-* [Which forum](which-forum.html) to use for communication:
+* [Which forum](which-forum) to use for communication:
   Issue tracker, Slack chat, Discuss discussion, GitHub pull requests.
   Some guidelines about when to use each, and some usage tips.

--- a/community/index.md
+++ b/community/index.md
@@ -46,3 +46,5 @@ There are many ways to contribute to FOLIO development:
 * [Which forum](which-forum) to use for communication:
   Issue tracker, Slack chat, Discuss discussion, GitHub pull requests.
   Some guidelines about when to use each, and some usage tips.
+
+* [Guidelines for FOLIO issue tracker](guide-issues).

--- a/community/index.md
+++ b/community/index.md
@@ -3,7 +3,7 @@ layout: page
 title: FOLIO Community
 ---
 
-## Collaboration Tools
+## Collaboration tools
 
 The discussion area and mailing lists for the FOLIO project are located at:
 [https://discuss.folio.org](https://discuss.folio.org)
@@ -16,7 +16,7 @@ The issue/bug tracking system is at: [https://issues.folio.org](https://issues.f
 
 Source code is on GitHub: [https://github.com/folio-org](https://github.com/folio-org)
 
-## Developer Community
+## Developer community
 
 The FOLIO developer community consists of:
 
@@ -31,7 +31,16 @@ Slack or the discussion site.
 
 There are many ways to contribute to FOLIO development:
 
-* Contributing directly to the software development.  (See the
-  [Guidelines for Contributing Code](contrib-code.html).)
+* Contributing directly to the software development.
 * Engaging with the issue tracker.
 * Joining the conversation on Slack or the discussion site.
+
+## Guidelines
+
+* [Guidelines for Contributing Code](contrib-code.html):
+  GitHub Flow, feature branches, pull requests, version numbers, coding style,
+  tests, etc.
+
+* [Which forum](which-forum.html) to use for communication:
+  Issue tracker, Slack chat, Discuss discussion, GitHub pull requests.
+  Some guidelines about when to use each, and some usage tips.

--- a/community/which-forum.md
+++ b/community/which-forum.md
@@ -66,16 +66,23 @@ we have four main fora:
 [https://folio-project.slack.com](https://folio-project.slack.com)
 (join [here](https://su17s9g5c5.execute-api.us-east-1.amazonaws.com/production) first).
 
-- [TODO: Explain when this is ideal.]
+- Real-time chat and messaging.
+
+- [TODO: Explain more about when this is ideal.]
 
 - Follow up on missed topics. This can occur when a flurry happens about
   other topics. Also everyone is busy, and may intend to respond later.
   So pursue topics at a later time or venue.
 
-- Great as a brainstorming session. Try to choose a time that suits people
+- A place to get together to solve a particular bug,
+  or hold a brainstorming session. Try to choose a time that suits people
   distributed around the world.
 
 - Summarise topics out to other forums for better visibility.
+
+- A place for fun banter between colleagues.
+
+- A place for heads-up type of notices.
 
 ## Issue tracker
 

--- a/community/which-forum.md
+++ b/community/which-forum.md
@@ -7,15 +7,22 @@ Developers need to efficiently discuss various topics such as issues, usage quir
 Remember that other developers, the recipients of your messages, are also busy.
 They also operate in different time zones. In such busy projects, items can be easily overlooked, especially when in an inappropriate forum.
 
+We follow a variation of the Apache motto:
+**_If it didn't happen in one of the primary communication channels (Discuss, Wiki, Issues, and GitHub), it didn't happen._**
 We each need to pause and consider the best forum. There are no rules, but these guidelines can assist.
 
 As explained in the
 [collaboration tools](../community/#collaboration-tools) section,
-we have four main fora:
-[Discuss](#discuss) and mailing lists,
-[Slack](#slack) chat and messaging,
-[Issue Tracker](#issue-tracker), and
-[GitHub](#github).
+we have four primary fora:
+[Discuss](#discuss) (messaging forum),
+[Wiki](#wiki) (documents),
+[Issues](#issue-tracker) (bug and task tracking), and
+[GitHub](#github) (source code and pull requests).
+There are also secondary communication channels, including:
+[Slack](#slack) (realtime chat),
+[WebEx](#webex) (conference calls), and in-person meetings.  
+If something important occurs in a secondary channel, it must be recorded in a primary channel (Discuss, Wiki, Issues, or GitHub).
+
 
 ## General notes
 
@@ -23,7 +30,7 @@ we have four main fora:
   [FOLIO Communication Spaces](https://wiki.folio.org/display/COMMUNITY/FOLIO+Communication+Spaces).
 
 - Decisions need to be recorded in an appropriate place.
-  Sometimes that will be the Issue Tracker, sometimes as Discuss topics.
+  Sometimes that will be the Issue Tracker, sometimes as Discuss topics, sometimes it will be as a position paper on the wiki.
 
 - Use well-chosen words for topic titles and introductory sections.
   This will make it easier to later list and search.
@@ -31,6 +38,7 @@ we have four main fora:
 - Make links in each topic, e.g. between an issue tracker item and
   relevant Discuss topics. Our future selves will be thankful when
   we need to explore the reasons for a certain change.
+  Note that it is also possible to copy links from the Slack archive into
 
 - Try to search before starting a new topic. If there are duplicates,
   then link them.
@@ -61,28 +69,9 @@ we have four main fora:
 
 - When seeking input from the broadest reach of FOLIO participants.
 
-## Slack
+## Wiki
 
-[https://folio-project.slack.com](https://folio-project.slack.com)
-(join [here](https://su17s9g5c5.execute-api.us-east-1.amazonaws.com/production) first).
-
-- Real-time chat and messaging.
-
-- [TODO: Explain more about when this is ideal.]
-
-- Follow up on missed topics. This can occur when a flurry happens about
-  other topics. Also everyone is busy, and may intend to respond later.
-  So pursue topics at a later time or venue.
-
-- A place to get together to solve a particular bug,
-  or hold a brainstorming session. Try to choose a time that suits people
-  distributed around the world.
-
-- Summarise topics out to other forums for better visibility.
-
-- A place for fun banter between colleagues.
-
-- A place for heads-up type of notices.
+[https://wiki.folio.org](https://wiki.folio.org)
 
 ## Issue tracker
 
@@ -93,7 +82,7 @@ we have four main fora:
 - Also tasks that you know need to be done sometime later.
 
 - If not clear whether to add a new issue, then commence a
-  Discuss topic first, and later summarise into an Issue.
+  Discuss topic first, and later summarize into an Issue.
 
 - Describe the issue concisely in the Summary and Description fields.
   Use Comments for further detail.
@@ -125,3 +114,24 @@ we have four main fora:
   their Pull Requests or in direct response to their Commits (see
   [example](https://github.com/folio-org/okapi/commit/710e201053897609ceb667e0687f830f92f9d006)).
 
+## Slack
+
+[https://folio-project.slack.com](https://folio-project.slack.com)
+(join [here](https://su17s9g5c5.execute-api.us-east-1.amazonaws.com/production) first).
+
+- Real-time chat and messaging.
+
+- Summarize topics out to other forums for better visibility.
+  Remember that Slack is a secondary channel;  significant ideas and decisions must be recorded elsewhere (Discuss, Wiki, Issues or GitHub) for broader vetting.
+
+- Follow up on missed topics. This can occur when a flurry happens about
+  other topics. Also everyone is busy, and may intend to respond later.
+  So pursue topics at a later time or venue.
+
+- A place to get together to solve a particular bug,
+  or hold a brainstorming session. Try to choose a time that suits people
+  distributed around the world.
+
+- A place for fun banter between colleagues.
+
+- A place for heads-up type of notices.

--- a/community/which-forum.md
+++ b/community/which-forum.md
@@ -12,7 +12,10 @@ We each need to pause and consider the best forum. There are no rules, but these
 As explained in the
 [collaboration tools](../community/#collaboration-tools) section,
 we have four main fora:
-**Discuss** and mailing lists, **Slack**, **Issue Tracker**, and **GitHub**.
+[Discuss](#discuss) and mailing lists,
+[Slack](#slack) chat and messaging,
+[Issue Tracker](#issue-tracker), and
+[GitHub](#github).
 
 ## General notes
 
@@ -38,6 +41,41 @@ we have four main fora:
   For example, if your feedback is about a certain GitHub commit, then
   use its comment-on-commit facility.
   Likewise with pull requests and JIRA issue tracker.
+
+## Discuss
+
+[https://discuss.folio.org](https://discuss.folio.org)
+
+- For asking questions and recording discussions.
+
+- Use the relevant categories.
+
+- For topics that need lengthy or open-ended discussion, this is
+  definitely the place.
+
+- If in doubt about which forum to commence a discussion, then using a
+  Discuss topic is the best place.
+
+- You might be subsequently asked to explicitly add an Issue Tracker item.
+  Link in both directions.
+
+- When seeking input from the broadest reach of FOLIO participants.
+
+## Slack
+
+[https://folio-project.slack.com](https://folio-project.slack.com)
+(join [here](https://su17s9g5c5.execute-api.us-east-1.amazonaws.com/production) first).
+
+- [TODO: Explain when this is ideal.]
+
+- Follow up on missed topics. This can occur when a flurry happens about
+  other topics. Also everyone is busy, and may intend to respond later.
+  So pursue topics at a later time or venue.
+
+- Great as a brainstorming session. Try to choose a time that suits people
+  distributed around the world.
+
+- Summarise topics out to other forums for better visibility.
 
 ## Issue tracker
 
@@ -79,37 +117,3 @@ we have four main fora:
   their Pull Requests or in direct response to their Commits (see
   [example](https://github.com/folio-org/okapi/commit/710e201053897609ceb667e0687f830f92f9d006)).
 
-## Discuss
-
-[https://discuss.folio.org](https://discuss.folio.org)
-
-- For asking questions and recording discussions.
-
-- Use the relevant categories.
-
-- For topics that need lengthy or open-ended discussion, this is
-  definitely the place.
-
-- If in doubt about which forum to commence a discussion, then using a
-  Discuss topic is the best place.
-
-- You might be subsequently asked to explicitly add an Issue Tracker item.
-  Link in both directions.
-
-- When seeking input from the broadest reach of FOLIO participants.
-
-## Slack
-
-[https://folio-project.slack.com](https://folio-project.slack.com)
-(join [here](https://su17s9g5c5.execute-api.us-east-1.amazonaws.com/production) first).
-
-- [TODO: Explain when this is ideal.]
-
-- Follow up on missed topics. This can occur when a flurry happens about
-  other topics. Also everyone is busy, and may intend to respond later.
-  So pursue topics at a later time or venue.
-
-- Great as a brainstorming session. Try to choose a time that suits people
-  distributed around the world.
-
-- Summarise topics out to other forums for better visibility.

--- a/community/which-forum.md
+++ b/community/which-forum.md
@@ -1,0 +1,115 @@
+---
+layout: page
+title: Which forum to use for communication
+---
+
+Developers need to efficiently discuss various topics such as issues, usage quirks, new features, and documentation improvements.
+Remember that other developers, the recipients of your messages, are also busy.
+They also operate in different time zones. In such busy projects, items can be easily overlooked, especially when in an inappropriate forum.
+
+We each need to pause and consider the best forum. There are no rules, but these guidelines can assist.
+
+As explained in the
+[collaboration tools](../community/#collaboration-tools) section,
+we have four main fora:
+**Discuss** and mailing lists, **Slack**, **Issue Tracker**, and **GitHub**.
+
+## General notes
+
+- See also other notes about
+  [FOLIO Communication Spaces](https://wiki.folio.org/display/COMMUNITY/FOLIO+Communication+Spaces)
+
+- Decisions need to be recorded in an appropriate place.
+  Sometimes that will be the Issue Tracker, sometimes as Discuss topics.
+
+- Use well-chosen words for topic titles and introductory sections.
+  This will make it easier to later list and search.
+
+- Make links in each topic, e.g. between an issue tracker item and
+  relevant Discuss topics. Our future selves will be thankful when
+  we need to explore the reasons for a certain change.
+
+- Try to search before starting a new topic. If there are duplicates,
+  then link them.
+
+- Do not expect immediate answers.
+
+- Try to keep discussion focussed, and as close to the item as possible.
+  For example, if your feedback is about a certain GitHub commit, then
+  use its comment-on-commit facility.
+  Likewise with pull requests and JIRA issue tracker.
+
+## Issue tracker
+
+[https://issues.folio.org](https://issues.folio.org)
+
+- Specific bugs, problems, feature requests.
+
+- Also tasks that you know need to be done sometime later.
+
+- If not clear whether to add a new issue, then commence a
+  Discuss topic first, and later summarise into an Issue.
+
+- Describe the issue concisely in the Summary and Description fields.
+  Use Comments for further detail.
+
+- Follow up in other fora for any lengthy discussion.
+  Then summarise into further issue tracker comments.
+  Provide links in both directions.
+
+## GitHub
+
+[https://github.com/folio-org](https://github.com/folio-org)
+
+- As explained in
+  [Guidelines for Contributing Code](contrib-code.html),
+  use Feature Branches for any task beyond a minor text edit.
+
+- Use a descriptive name for the branch, with an Issue tracker number
+  if relevant, e.g. "folio-293-which-forum".
+
+- In the Pull Request, describe your main changes. Also say whether
+  it is now ready to merge, or that you are seeking feedback.
+
+- To seek feedback on your work, use additional comments on your
+  Pull Request. If the specific attention of certain people is needed,
+  then @mention their names.
+
+- For specific comments on the work of other people, add comments to
+  their Pull Requests or in direct response to their Commits (see
+  [example](https://github.com/folio-org/okapi/commit/710e201053897609ceb667e0687f830f92f9d006)).
+
+## Discuss
+
+[https://discuss.folio.org](https://discuss.folio.org)
+
+- For asking questions and recording discussions.
+
+- Use the relevant categories.
+
+- For topics that need lengthy or open-ended discussion, this is
+  definitely the place.
+
+- If in doubt about which forum to commence a discussion, then using a
+  Discuss topic is the best place.
+
+- You might be subsequently asked to explicitly add an Issue Tracker item.
+  Link in both directions.
+
+- When seeking input from the broadest reach of FOLIO participants.
+
+## Slack
+
+[https://folio-project.slack.com](https://folio-project.slack.com)
+(join [here](https://su17s9g5c5.execute-api.us-east-1.amazonaws.com/production) first).
+
+- [TODO: Explain when this is ideal.]
+
+- Follow up on missed topics. This can occur when a flurry happens about
+  other topics. Also everyone is busy, and may intend to respond later.
+  So pursue topics at a later time or venue.
+
+- Great as a brainstorming session. Try to choose a time that suits people
+  distributed around the world.
+
+- Summarise topics out to other forums for better visibility.

--- a/community/which-forum.md
+++ b/community/which-forum.md
@@ -20,7 +20,7 @@ we have four main fora:
 ## General notes
 
 - See also other notes about
-  [FOLIO Communication Spaces](https://wiki.folio.org/display/COMMUNITY/FOLIO+Communication+Spaces)
+  [FOLIO Communication Spaces](https://wiki.folio.org/display/COMMUNITY/FOLIO+Communication+Spaces).
 
 - Decisions need to be recorded in an appropriate place.
   Sometimes that will be the Issue Tracker, sometimes as Discuss topics.
@@ -90,6 +90,7 @@ we have four main fora:
 
 - Describe the issue concisely in the Summary and Description fields.
   Use Comments for further detail.
+  See [Guidelines for FOLIO issue tracker](guide-issues).
 
 - Follow up in other fora for any lengthy discussion.
   Then summarise into further issue tracker comments.

--- a/doc/index.md
+++ b/doc/index.md
@@ -13,16 +13,18 @@ together.
 
 In the context of those early chapters, you may then wish to go on to:
 
-## Core Code
+## Community and contribution
 
-Most important is the
+The [community section](../community/) explains how to be involved,
+provides the contribution guidelines, lists the various collaboration tools
+and has some recommendations about when to use each.
+
+## Core code
+
+The most important technical document is the
 [Okapi Guide and Reference](https://github.com/folio-org/okapi/blob/master/doc/guide.md),
-which after the introductory sections already described goes into
+which after the introductory sections already described, goes into
 detail about the Okapi API Gateway that controls a FOLIO system.
-
-The
-[contribution guidelines](https://github.com/folio-org/okapi/blob/master/CONTRIBUTING.md)
-for Okapi also pertain to FOLIO more broadly, and explain how to get involved.
 
 ## Modules
 

--- a/source-code/index.md
+++ b/source-code/index.md
@@ -33,10 +33,10 @@ fall into neither of these categories.
 
 **PLEASE NOTE** that this is a technology preview following the [release early,
 release often](https://en.wikipedia.org/wiki/Release_early,_release_often)
-philosophy.  **We want your feedback**, in the form of pull requests, [filed
-issues](https://issues.folio.org/) and general discussion on the [Slack-based
-chat forum](https://folio-project.slack.com/) or the [Discuss web
-forum](https://discuss.folio.org).
+philosophy.  **We want your feedback**, in the form of pull requests, filed
+issues, and general discussion on the Slack-based chat forum or the
+Discuss web forum
+(see [guidelines](../community/which-forum)).
 
 ## Server-side
 


### PR DESCRIPTION
(Not quite yet ready to merge.)

Addresses FOLIO-293 with the community/which-forum doc.
Also addresses FOLIO-298 with the community/guide-issues doc.

The main missing piece, is to say a bit more in the section about Slack.

Both docs could have a bit more general content, but that can be done in a later round.