### PR TITLE
General tidy and sync copies of contribution guide

### DIFF
--- a/community/contrib-code.md
+++ b/community/contrib-code.md
@@ -74,15 +74,20 @@ branch. If there are serious issues, you can close the pull request without
 merging, with a comment explaining why you could not do it.
 
 Once all is well, you can use GitHub's interface. Just go to the
-conversation tab, and click on _Merge Pull Request_, edit the comment if
+conversation tab, and click on _Merge Pull Request_ (don't squash, don't rebase,
+[learn why](https://git-scm.com/book/en/v2/Git-Branching-Rebasing#The-Perils-of-Rebasing)).
+Edit the comment if
 necessary, and click on _Confirm Merge_. GitHub should tell you that the
 _Pull request successfully merged and closed_. Next to it is a button to
 _Delete the Branch_. For a simple feature branch, you might as well delete
 it now, it has served its purpose. But if you think there is more work that
 should be done in this branch, of course you don't delete it.
 
-This merging can also be done on the command line, if you prefer
-(TODO - Describe how)
+This merging of the pull request's branch okapi-xxx can also be done on the
+command line, if you prefer.
+
+    git checkout master
+    git merge okapi-xxx
 
 When done, you probably want to delete the local branch from your own machine
 

--- a/community/contrib-code.md
+++ b/community/contrib-code.md
@@ -5,8 +5,8 @@ title: Guidelines for Contributing Code
 
 ## Git and branches
 
-For all FOLIO code repositories, we are trying to follow [GitHub
-Flow](https://guides.github.com/introduction/flow/).
+For all FOLIO code repositories, we are trying to follow
+[GitHub Flow](https://guides.github.com/introduction/flow/).
 
 In short, the master branch is always the head of latest development. Anything
 merged into master should be of such good quality that at any time a snapshot
@@ -20,11 +20,12 @@ small trivial change directly in the master. Stuff like editing the README.
 ### Feature branches
 
 Feature branches should be branched off from the master. The naming of those
-is not strict, but if you start a branch to fix issue _#7_ in GitHub issue
-tracker, you might well call the branch _gh-7_, or if you want to be more
-descriptive, something like _gh-7-contribution-guidelines_
+is not strict, but if you start a branch to fix issue okapi-xxx filed in
+[issues.folio.org](https://issues.folio.org/) then you might well call the
+branch _okapi-xxx_ (or if you want to be more descriptive, something
+like _okapi-xxx-contribution-guidelines_):
 
-    git checkout -b gh-7
+    git checkout -b okapi-xxx
 
 You can commit stuff as you go, but try not push obviously broken stuff into
 GitHub, not even in your development branch - that will be visible for the
@@ -34,10 +35,10 @@ code, for example for collaborating, of course you need to push it. Naturally
 you will write decent commit messages explaining what you have done.
 
 The first time you want to push your branch to GitHub, you may encounter an
-error _The current branch gh-7 has no upstream branch_. Git tells you what to
-do, namely
+error _The current branch okapi-xxx has no upstream branch_. Git tells you
+what to do, namely:
 
-    git push --set-upstream origin gh-7
+    git push --set-upstream origin okapi-xxx
 
 Once you have done that, a simple `git push` will be sufficient.
 
@@ -91,7 +92,7 @@ command line, if you prefer.
 
 When done, you probably want to delete the local branch from your own machine
 
-    git branch -d gh-7
+    git branch -d okapi-xxx
 
 (TODO - Describe the automatic testing, when it is up and running)
 
@@ -184,8 +185,7 @@ Do not release modules with a version number ending in `.0`.
 ## Coding style
 
 For Java code, we basically try to adhere to Sun Java coding
-conventions, as in
-http://www.oracle.com/technetwork/java/codeconvtoc-136057.html
+[conventions](http://www.oracle.com/technetwork/java/codeconvtoc-136057.html)
 (That document is old and unmaintained, but seems to be good enough as it is)
 
 There are a few exceptions:
@@ -198,7 +198,8 @@ since those produce unnecessary diffs in Git.
 
 ## License
 
-Licensed under the Apache License, Version 2.0.
+Licensed under the Apache License, Version 2.0 (see [LICENSE](LICENSE)).
+See [background](http://www.apache.org/licenses/) information.
 
 ## Tests
 
@@ -209,9 +210,10 @@ that talk through the WS API, and/or proper integration tests.
 When hunting down problems, it is considered good form to write a test that
 demonstrates the problem first, then a fix that makes the test pass.
 
-We have a Jenkins test system that gets invoked when you push something to master,
-and/or make a pull request. It should flag any errors, but be nice and run a
-```mvn install``` on your own machine before every ```git commit```
+We have a Jenkins test system that gets invoked when you push something
+to master, and/or make a pull request. It should flag any errors, but be
+nice and run a ```mvn install``` on your own machine before every
+```git commit```
 
 ## RAML
 

--- a/community/contrib-code.md
+++ b/community/contrib-code.md
@@ -16,7 +16,6 @@ will be free of bugs; we are not superhuman.
 All real work should be done in feature branches. It is still OK to make a
 small trivial change directly in the master. Stuff like editing the README.
 
-
 ### Feature branches
 
 Feature branches should be branched off from the master. The naming of those
@@ -63,7 +62,6 @@ It should show you that it is _able to merge_, so click on the "Create Pull
 Request" button under the comment box. Once the request is created, assign it
 to someone else.
 
-
 ### Merging pull requests
 
 When someone has assigned a pull request to you, check out the branch, and
@@ -101,11 +99,11 @@ When done, you probably want to delete the local branch from your own machine
 The exact procedure for making a release is not yet specified. It is likely to
 be something like we are doing for other software:
 
-* Freeze the master for a short while
-* Make a release branch
-* Make changes specific for this release in the branch
-* Tag a version
-* Package and release it
+- Freeze the master for a short while
+- Make a release branch
+- Make changes specific for this release in the branch
+- Tag a version
+- Package and release it
 
 Later, if there are bugs in the released version, work can continue on the
 version branch, and we can release a new minor version from the branch. Some
@@ -114,43 +112,44 @@ master, as need be.
 
 ## Version numbers
 
-Since (almost?) all our stuff is web services, we need to keep two kind of
+Since (almost) all our stuff is web services, we need to keep two kind of
 version numbers, one for the API, and one for the implementation code. To
 make matters worse, a module may implement several interfaces.
 
-
 ### API versions
 
-The API versions are the most important. They are two-part numbers, as in 3.14.
+The API versions are the most important. They are two-part numbers,
+such as `3.14`
 
 The rules are simple:
 
-* If you only add things to the interface, you increment the minor number,
+- If you only add things to the interface, you increment the minor number,
   because the API is backwards compatible.
-* If you remove or change anything, you must increment the major number, because
-  now your API is no longer backwards compatible.
+- If you remove or change anything, you must increment the major number,
+  because now your API is no longer backwards compatible.
 
-For example, you can add a new function to 3.14, and call it 3.15. Any module
-that requires 3.14 can also use 3.15. But if you remove anything from the API,
-or change the meaning of a parameter, you need to bump the API version to 4.1.
+For example, you can add a new function to `3.14`, and call it `3.15`.
+Any module that requires `3.14` can also use `3.15`. But if you remove
+anything from the API, or change the meaning of a parameter, you need to
+bump the API version to `4.1`
 
 ### Implementation versions
 
-The module versions are in 3 parts, like 3.14.15
+The module versions are three-part part numbers, such as `3.14.15`
 
-* The last part should be incremented if you haven't changed anything in the API,
-  but only fixed bugs, etc.
-* The middle part should be incremented if you added something to the API, and
+- The last part should be incremented if you haven't changed anything in
+  the API, but only fixed bugs, etc.
+- The middle part should be incremented if you added something to the API, and
   incremented the minor API version.
-* The major part should be incremented if you made a backwards incompatible change
-  to the API, and incremented its major number.
-
+- The major part should be incremented if you made a backwards incompatible
+  change to the API, and incremented its major number.
 
 ### The simple case
 
 In the most simple case, a module implements just one interface. Then we can
-keep the two versions in sync, so module version 3.14.01 implements the interface
-3.14, and the last part shows that this is the first version that does so.
+keep the two versions in sync, so module version `3.14.01` implements the
+interface `3.14`, and the last part shows that this is the first version
+that does so.
 
 ### Complex cases
 
@@ -159,46 +158,47 @@ of any of them. In that case the version numbering is necessarily more complex.
 There does not have to be any correlation between the module version and the
 version of the interfaces it implements.
 
-For example, if the circulation module version 3.14.1 can implement the checkout
-API version 1.4 and the checkin API version 2.7. The rules are still the same:
+For example, if the circulation module version `3.14.1` can implement the
+checkout API version `1.4` and the checkin API version `2.7` then the
+rules are still the same:
 
-* If you don't change any API, increment the last part to 3.14.2
-* If you add new features to _any_ API, increment the middle part to 3.15.1
-* If you make any backwards incompatible change to _any_ API, or drop _any_
-  API at all, increment the module version to 4.1.1
+- If you don't change any API, increment the last part to `3.14.2`
+- If you add new features to _any_ API, increment the middle part to `3.15.1`
+- If you make any backwards incompatible change to _any_ API, or drop _any_
+  API at all, increment the module version to `4.1.1`
 
 The most common case is probably when we need to add a new, incompatible API
 to a module, but want to keep the old one too. In such cases we only increment
-the module version to 3.15.1, but mark that it provides the API versions 3.14
-and 4.1.
+the module version to `3.15.1` but mark that it provides the API versions
+`3.14` and `4.1`
 
 ### Dot one, not zero
+
 The version numbers that end in zero are special, they are reserved for filing
 issues for the next version. If you have a small thing you want to add next
-time we change the minor version, label the issue with something like v3.15.0
-or even v4.0.0 if the change is not backwards compatible. When the change gets
-implemented, we bump the version number to 3.15.1 or 4.1.1.
+time we change the minor version, label the issue with something like `v3.15.0`
+or even `v4.0.0` if the change is not backwards compatible. When the change
+gets implemented, we bump the version number to `3.15.1` or `4.1.1`
 
-Do not release modules with a version number ending in `.0`.
-
+Do not release modules with a version number ending in `.0`
 
 ## Coding style
 
 For Java code, we basically try to adhere to Sun Java coding
 [conventions](http://www.oracle.com/technetwork/java/codeconvtoc-136057.html)
-(That document is old and unmaintained, but seems to be good enough as it is)
+(that document is old and unmaintained, but seems to be good enough as it is).
 
 There are a few exceptions:
 
-* We indent with two spaces only, because vert.x uses deeply nested callbacks.
-* We _don't_ use tab characters for indents, only spaces
+- We indent with two spaces only, because vert.x uses deeply nested callbacks.
+- We _don't_ use tab characters for indents, only spaces.
 
 Remember to set your IDE to remove trailing spaces on saving files,
 since those produce unnecessary diffs in Git.
 
 ## License
 
-Licensed under the Apache License, Version 2.0 (see [LICENSE](LICENSE)).
+Licensed under the Apache License, Version 2.0 (see [LICENSE](../LICENSE)).
 See [background](http://www.apache.org/licenses/) information.
 
 ## Tests
@@ -217,6 +217,6 @@ nice and run a ```mvn install``` on your own machine before every
 
 ## RAML
 
-We keep the API specs in RAML files under okapi-core/src/main/raml/. Remember to
-update those if you ever change anything in the API. And update the documentation
-too, of course.
+We keep the API specs in RAML files under okapi-core/src/main/raml/.
+Remember to update those if you ever change anything in the API.
+And update the documentation too, of course.

--- a/community/index.md
+++ b/community/index.md
@@ -25,9 +25,9 @@ See guidelines about the
 
 The FOLIO developer community consists of:
 
-* Several software engineering teams with commit access to specific
+- Several software engineering teams with commit access to specific
   platform components, such as Okapi.
-* Contributors from the community.
+- Contributors from the community.
 
 Team members can be contacted via the collaboration tools.
 
@@ -35,14 +35,14 @@ Team members can be contacted via the collaboration tools.
 
 There are many ways to contribute to FOLIO development:
 
-* Contributing directly to the software development.
-* Engaging with the issue tracker.
-* Joining the conversations.
+- Contributing directly to the software development.
+- Engaging with the issue tracker.
+- Joining the conversations.
 
 ## Guidelines
 
-* [Guidelines for Contributing Code](contrib-code):
+- [Guidelines for Contributing Code](contrib-code):
   GitHub Flow, feature branches, pull requests, version numbers, coding style,
   tests, etc.
 
-* [FOLIO Communication Spaces](https://wiki.folio.org/display/COMMUNITY/FOLIO+Communication+Spaces).
+- [FOLIO Communication Spaces](https://wiki.folio.org/display/COMMUNITY/FOLIO+Communication+Spaces).

--- a/doc/index.md
+++ b/doc/index.md
@@ -42,8 +42,8 @@ of interest.
 
 The FOLIO user-interface toolkit is called Stripes. It is described in
 [Stripes: a modular toolkit for user
-interfaces](https://github.com/folio-org/stripes-experiments/blob/master/stripes-core/doc/overview.md)
-and instruction for running a Stripes-based UI can be found in
+interfaces](https://github.com/folio-org/stripes-experiments/blob/master/stripes-core/doc/overview.md).
+Instructions for running a Stripes-based UI can be found in
 [the Stripes Core README file](https://github.com/folio-org/stripes-experiments/blob/master/stripes-core/README.md).
 
 Related to this,
@@ -57,10 +57,10 @@ These API specification are automatically generated from the relevant
 [RAML](http://raml.org/) files, and specify how client modules may
 access the functionality provided by these important core modules.
 
-* [Patrons API](http://foliodocs.s3-website-us-east-1.amazonaws.com/raml/dist/patrons.html)
-* [Bib API](http://foliodocs.s3-website-us-east-1.amazonaws.com/raml/dist/bibs.html)
-* [Configurations API](http://foliodocs.s3-website-us-east-1.amazonaws.com/raml/dist/config.html)
-* [Item API](http://foliodocs.s3-website-us-east-1.amazonaws.com/raml/dist/items.html)
+- [Patrons API](http://foliodocs.s3-website-us-east-1.amazonaws.com/raml/dist/patrons.html)
+- [Bib API](http://foliodocs.s3-website-us-east-1.amazonaws.com/raml/dist/bibs.html)
+- [Configurations API](http://foliodocs.s3-website-us-east-1.amazonaws.com/raml/dist/config.html)
+- [Item API](http://foliodocs.s3-website-us-east-1.amazonaws.com/raml/dist/items.html)
 
 ## Glossary
 

--- a/index.md
+++ b/index.md
@@ -26,5 +26,5 @@ nascent, we expect it to evolve quickly in the coming weeks.
 
 We hope you will join FOLIO and help us shape the future of libraries!  We
 invite you to provide feedback and explore ideas with us.  Join the
-conversation over at [folio.org](https://www.folio.org/).
+conversation over at [folio.org](https://www.folio.org/)
 

--- a/source-code/index.md
+++ b/source-code/index.md
@@ -13,23 +13,22 @@ organization](https://github.com/folio-org) host the core project code.
 Third-party modules may be hosted elsewhere.
 
 A good starting point for understanding the FOLIO code is
-[Okapi](https://github.com/folio-org/okapi) -- specifically the [Okapi Guide and
-Reference](https://github.com/folio-org/okapi/blob/master/doc/guide.md), which
+[Okapi](https://github.com/folio-org/okapi) -- specifically the
+[Okapi Guide and Reference](https://github.com/folio-org/okapi/blob/master/doc/guide.md), which
 introduces the concepts and architecture of the FOLIO platform, and includes
 installation instructions and examples.  Okapi is the central hub for
 applications running on the FOLIO platform and enables access to other modules
 in the architecture.
 
 The FOLIO system is made up of the code in several GitHub repositories.
-Each repository contains the code for a single well-defined element of the system. These repositories fall into three
-categories:
+Each repository contains the code for a single well-defined element of the
+system. These repositories fall into three categories:
 
-* _server-side elements_ that provide services and the
-infrastructure that they run on;
-* _client-side elements_ that provide a
-framework for using those services from a Web browser;
-* and a few that
-fall into neither of these categories.
+- _server-side elements_ that provide services and the
+  infrastructure that they run on;
+- _client-side elements_ that provide a
+  framework for using those services from a Web browser;
+- and a few that fall into neither of these categories.
 
 **PLEASE NOTE** that this is a technology preview following the [release early,
 release often](https://en.wikipedia.org/wiki/Release_early,_release_often)
@@ -47,34 +46,39 @@ Some of these modules are built from specifications in
 [RAML](http://raml.org/), the RESTful API Modeling Language: this process is
 facilitated by the code in the `raml-module-builder` repository.
 
-* [okapi](https://github.com/folio-org/okapi) --
-Okapi API Gateway proxy/discovery/deployment service.
+- [okapi](https://github.com/folio-org/okapi)
+  -- Okapi API Gateway proxy/discovery/deployment service.
 
-* [raml-module-builder](https://github.com/folio-org/raml-module-builder) --
-framework facilitating easy module creation based on RAML files.
+- [raml-module-builder](https://github.com/folio-org/raml-module-builder)
+  -- Framework facilitating easy module creation based on RAML files.
 
-* [mod-circulation](https://github.com/folio-org/mod-circulation) --
-circulation demo based on the raml-module-builder and a set of RAML and JSON Schemas. Represents some of the necessary circulation functionality against MongoDB.
+- [mod-circulation](https://github.com/folio-org/mod-circulation)
+  -- Circulation demo based on the raml-module-builder and a set of RAML and
+  JSON Schemas. Represents some of the necessary circulation functionality
+  against MongoDB.
 
-* [mod-acquisitions](https://github.com/folio-org/mod-acquisitions) --
-demo acquisitions module, based on the raml-module-builder framework, exposing acquisition APIs and objects against MongoDB.
+- [mod-acquisitions](https://github.com/folio-org/mod-acquisitions)
+  -- Demo acquisitions module, based on the raml-module-builder framework,
+  exposing acquisition APIs and objects against MongoDB.
 
-* [mod-acquisitions-postgres](https://github.com/folio-org/mod-acquisitions-postgres) --
-a second demo acquisitions module, also based on the
-raml-module-builder framework and exposing acquisition APIs and
-objects, but implemented with an asynchronous Postgres client.
+- [mod-acquisitions-postgres](https://github.com/folio-org/mod-acquisitions-postgres)
+  -- A second demo acquisitions module, also based on the
+  raml-module-builder framework and exposing acquisition APIs and
+  objects, but implemented with an asynchronous Postgres client.
 
-* [mod-configuration](https://github.com/folio-org/mod-configuration) --
-demo configuration module based on the raml-module-builder and a set of RAML and JSON Schemas backed by a MongoDB asynchronous implementation.
+- [mod-configuration](https://github.com/folio-org/mod-configuration)
+  -- Demo configuration module based on the raml-module-builder and a set
+  of RAML and JSON Schemas backed by a MongoDB asynchronous implementation.
 
-* [mod-auth](https://github.com/folio-org/mod-auth) --
-Prototype of a [JWT](https://jwt.io/)-based
-authentication/authorization module. Will be superseded by a more
-capable set of modules handling authentication by various methods,
-and generalized permissions-handling.
+- [mod-auth](https://github.com/folio-org/mod-auth)
+  -- Prototype of a [JWT](https://jwt.io/)-based
+  authentication/authorization module. Will be superseded by a more
+  capable set of modules handling authentication by various methods,
+  and generalized permissions-handling.
 
-* [mod-metadata](https://github.com/folio-org/mod-metadata) --
-Initial work on a FOLIO metadata store and related knowledge base/cataloging concepts.
+- [mod-metadata](https://github.com/folio-org/mod-metadata)
+  -- Initial work on a FOLIO metadata store and related
+  knowledge-base/cataloging concepts.
 
 ## Client-side
 
@@ -88,27 +92,27 @@ Stripes.
 Note that Stripes is still in the design phase, so although code
 exists and can be run, the APIs are likely to change.
 
-* [stripes-experiments](https://github.com/folio-org/stripes-experiments) --
-testing ground for prototype modules that may form part of
-Stripes. Most importantly, this contains `stripes-core`, which drives
-the whole process; and `stripes-connect`, which manages the connection
-of UI components to back-end modules.
+- [stripes-experiments](https://github.com/folio-org/stripes-experiments)
+  -- Testing ground for prototype modules that may form part of
+  Stripes. Most importantly, this contains `stripes-core`, which drives
+  the whole process; and `stripes-connect`, which manages the connection
+  of UI components to back-end modules.
 
-* [stripes-loader](https://github.com/folio-org/stripes-loader) --
-module loader for Webpack, to enable pluggable Redux
-applications. This module is responsible for pulling the required UI modules
-into a given Stripes UI.
+- [stripes-loader](https://github.com/folio-org/stripes-loader)
+  -- Module loader for Webpack, to enable pluggable Redux applications.
+  This module is responsible for pulling the required UI modules
+  into a given Stripes UI.
 
-* [okapi-stripes](https://github.com/folio-org/okapi-stripes) --
-server-side module for generating UIs based on Stripes.
+- [okapi-stripes](https://github.com/folio-org/okapi-stripes)
+  -- Server-side module for generating UIs based on Stripes.
 
 ## Other projects
 
-* [external-api-testing](https://github.com/folio-org/external-api-testing) --
-Various tests of Okapi's APIs.
+- [external-api-testing](https://github.com/folio-org/external-api-testing)
+  -- Various tests of Okapi's APIs.
 
-* [folio-sample-modules](https://github.com/folio-org/folio-sample-modules) --
-Various sample modules, illustrating ways to structure a module for
-use with Okapi (`hello-vertx` and `simple-vertx`) and how to make a
-client-side module (`patrons`).
+- [folio-sample-modules](https://github.com/folio-org/folio-sample-modules)
+  -- Various sample modules, illustrating ways to structure a module for
+  use with Okapi (`hello-vertx` and `simple-vertx`) and how to make a
+  client-side module (`patrons`).
 


### PR DESCRIPTION
Synchronise copies of doc "CONTRIBUTING.md" and "folio-org.github.io/community/contrib-code.md".
Apply some consistent Markdown style.