### PR TITLE
DMOD-88 api aws

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -3,6 +3,11 @@ okapi:
   directory: okapi-core/src/main/raml
   files: [okapi]
 
+raml-module-builder:
+  name: raml-module-builder
+  directory: domain-models-runtime/src/main/resources/raml
+  files: [admin, jobs, sample]
+
 mod-acquisitions:
   name: mod-acquisitions
   directory: ramls/acquisitions

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -5,7 +5,7 @@ title: API documentation
 
 This API documentation is generated from RAML files in each repository:
 
-{% assign url_aws = "http://foliodocs.s3-website-us-east-1.amazonaws.com/api" %}
+{% assign url_aws = "https://s3.amazonaws.com/foliodocs/api" %}
 
 <ul>
   {% for repo in site.data.api %}

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -9,6 +9,7 @@ files, and specify how client modules may
 access the functionality provided by these important core modules.
 
 {% assign url_aws = "https://s3.amazonaws.com/foliodocs/api" %}
+{% assign url_github= "https://github.com/folio-org" %}
 
 <ul>
   {% for repo in site.data.api %}
@@ -19,6 +20,7 @@ access the functionality provided by these important core modules.
             <a href="{{ url_aws }}/{{ repo[0] }}/{{ doc }}.html">
               {{ doc }}
             </a>
+            (<a href="{{ url_github }}/{{ repo[0] }}/blob/master/{{ repo[1].directory }}/{{ doc }}.raml">source</a>)
           </li>
         {% endfor %}
       </ul>

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -3,7 +3,10 @@ layout: page
 title: API documentation
 ---
 
-This API documentation is generated from RAML files in each repository:
+These API specifications are automatically generated from the relevant
+[RAML](https://github.com/folio-org/raml)
+files, and specify how client modules may
+access the functionality provided by these important core modules.
 
 {% assign url_aws = "https://s3.amazonaws.com/foliodocs/api" %}
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -56,26 +56,7 @@ using the Okapi Console front-end to deploy modules and see a list of users.
 
 ## API reference
 
-These API specifications are automatically generated from the relevant
-[RAML](https://github.com/folio-org/raml)
-files, and specify how client modules may
-access the functionality provided by these important core modules.
-(**Note:** The automated generation of these pages is being revised
-[DMOD-88](https://issues.folio.org/browse/DMOD-88).)
-
-- [Patrons API](http://foliodocs.s3-website-us-east-1.amazonaws.com/raml/dist/patrons.html)
-- [Bib API](http://foliodocs.s3-website-us-east-1.amazonaws.com/raml/dist/bibs.html)
-- [Configurations API](http://foliodocs.s3-website-us-east-1.amazonaws.com/raml/dist/config.html)
-- [Item API](http://foliodocs.s3-website-us-east-1.amazonaws.com/raml/dist/items.html)
-
-The following API specifications are automatically generated from the relevant
-[mod-metadata module](https://github.com/folio-org/mod-metadata) RAML
-files, and specify how client modules may access the functionality
-provided by this module.
-
-- [Catalogue API](http://foliodocs.s3-website-us-east-1.amazonaws.com/mod-metadata/catalogue.html)
-- [Knowledgebase API](http://foliodocs.s3-website-us-east-1.amazonaws.com/mod-metadata/knowledgebase.html)
-
+- The set of automatically generated [API documentation](api).
 
 ## Guidelines
 


### PR DESCRIPTION
DMOD-88
- Improve main page to also link to each raml source
- Better AWS URL
- Add configuration for raml-module-builder