### PR TITLE
DMOD-133 move user related 2

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -94,10 +94,3 @@ mod-inventory-storage:
       - loan-type
       - material-type
     ramlutil: raml-util
-
-mod-users-bl:
-  - label: null
-    directory: ramls
-    files:
-      - mod-users-bl
-    ramlutil: null

--- a/_data/api.yml
+++ b/_data/api.yml
@@ -95,29 +95,6 @@ mod-inventory-storage:
       - material-type
     ramlutil: raml-util
 
-mod-login:
-  - label: null
-    directory: ramls
-    files:
-      - login
-    ramlutil: null
-
-mod-permissions:
-  - label: null
-    directory: ramls
-    files:
-      - permissions
-      - permission_interface
-    ramlutil: null
-
-mod-users:
-  - label: null
-    directory: ramls
-    files:
-      - groups
-      - users
-    ramlutil: raml-util
-
 mod-users-bl:
   - label: null
     directory: ramls

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -8,6 +8,9 @@ These API specifications are automatically generated from the relevant
 files, and specify how client modules may
 access the functionality provided by these important core modules.
 
+* view-1: Uses pop-up windows for each method and endpoint.
+* view-2: Uses one-page view to everything.
+
 {% assign url_aws = "https://s3.amazonaws.com/foliodocs/api" %}
 {% assign url_github= "https://github.com/folio-org" %}
 


### PR DESCRIPTION
Ready to merge.

Removed configuration for user-related api docs, now moved to raml-util

Removed configuration for mod-users-bl until ready.