### PR TITLE
FOLIO-600-align-permissions-ramls

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -14,7 +14,6 @@ raml:
     directory: ramls
     files:
       - tenant
-      - tenantPermissions
     ramlutil: .
   - label: shared-mod-login
     directory: ramls/mod-login
@@ -24,8 +23,8 @@ raml:
   - label: shared-mod-permissions
     directory: ramls/mod-permissions
     files:
+      - tenantPermissions
       - permissions
-      - permission_interface
     ramlutil: .
   - label: shared-mod-users
     directory: ramls/mod-users


### PR DESCRIPTION
Remove old top-level file tenantPermissions FOLIO-600
now in folio-org/raml/ramls/mod-permissions