### PR TITLE
FOLIO-672 Use CSS :target to highlight anchor

### DIFF
--- a/_sass/_folio.scss
+++ b/_sass/_folio.scss
@@ -41,6 +41,9 @@ code {
   background-color: $f-color-lighter-grey;
 }
 
-#bottom-spacer {
-  padding-bottom: 50em;
+:target {
+  border-left: 5px solid $f-color-orange;
+}
+tr:target td:first-child {
+  border-left: 5px solid $f-color-orange;
 }

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -45,6 +45,3 @@ access the functionality provided by these important core modules.
   {% endfor %}
   </tbody>
 </table>
-<div id="bottom-spacer">
-<!-- Spacer to enable linking directly to each table row above. -->
-</div>


### PR DESCRIPTION
To highlight anchor sections and table rows,
especially near the bottom of the page.