### PR TITLE
Tweak docs 3

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -109,6 +109,7 @@ Configurations for accessing.
 
 ### Getting started
 
+- [Primer for back-end development](primer-develop-backend).
 - [Primer for front-end development](primer-develop-frontend).
 
 ### Reference documentation

--- a/doc/index.md
+++ b/doc/index.md
@@ -34,8 +34,7 @@ detail about the Okapi API Gateway that controls a FOLIO system.
 
 ## Modules
 
-The [FOLIO-Sample-Modules
-guide](https://github.com/folio-org/folio-sample-modules/blob/master/README.md)
+The [FOLIO-Sample-Modules guide](https://github.com/folio-org/folio-sample-modules/blob/master/README.md)
 contains an explanation of FOLIO modules, a "getting started" guide,
 and some sample module code.
 [Follow on](https://github.com/folio-org/folio-sample-modules/blob/master/README.md#further-reading)
@@ -110,7 +109,7 @@ Configurations for accessing.
 
 ### Getting started
 
-- [Primer for frontend development](primer-develop-frontend).
+- [Primer for front-end development](primer-develop-frontend).
 
 ### Reference documentation
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -82,6 +82,7 @@ The list of module versions for each box is shown in its change-log.
 * [Setup and configuration](#setup-and-configuration)
 * [Getting started](#getting-started)
 * [Reference documentation](#reference-documentation)
+* [Fundamental documentation](#fundamental-documentation)
 * [Development tips](#development-tips)
 * [Tutorials](#tutorials)
 * [Development management](#development-management)
@@ -117,11 +118,24 @@ Configurations for accessing.
 - [Overiew](reference) of all technical reference documentation.
 - <span id="api-reference"/> The set of automatically generated [API documentation](api).
 
+### Fundamental documentation
+
+- [Okapi Guide and Reference](https://github.com/folio-org/okapi/blob/master/doc/guide.md).
+- [FOLIO-Sample-Modules guide](https://github.com/folio-org/folio-sample-modules/blob/master/README.md).
+- [RAML Module Builder](https://github.com/folio-org/raml-module-builder) (RMB) framework.
+- Each [server-side](../source-code/#server-side) and [client-side](../source-code/#client-side)
+module's own documentation.
+- [Stripes Core README](https://github.com/folio-org/stripes-core/blob/master/README.md)
+guides to all front-end documentation.
+- [The Stripes Module Developer's Guide](https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md)
+for those writing UI modules for Stripes.
+- [Regression tests for FOLIO UI](https://github.com/folio-org/ui-testing).
+The testing framework is explained. Guidelines for module developers.
+- [Permissions in Stripes and FOLIO](https://github.com/folio-org/stripes-core/blob/master/doc/permissions.md).
+
 ### Development tips
 
 - Conduct [troubleshooting](troubleshooting).
-- [Regression tests for FOLIO UI](https://github.com/folio-org/ui-testing)
-The testing framework is explained. Guidelines for module developers.
 
 ### Tutorials
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -120,6 +120,8 @@ Configurations for accessing.
 ### Development tips
 
 - Conduct [troubleshooting](troubleshooting).
+- [Regression tests for FOLIO UI](https://github.com/folio-org/ui-testing)
+The testing framework is explained. Guidelines for module developers.
 
 ### Tutorials
 

--- a/doc/primer-develop-backend.md
+++ b/doc/primer-develop-backend.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Primer for back-end development
+---
+
+Start with introduction to [core code](/doc/#core-code)
+and the [server-side](/source-code/#server-side) source code repositories.
+
+The [Okapi Guide and Reference](https://github.com/folio-org/okapi/blob/master/doc/guide.md) provides the necessary background understanding.
+
+The [FOLIO-Sample-Modules guide](https://github.com/folio-org/folio-sample-modules/blob/master/README.md) further explains what is a server-side module and how to develop one. Importantly, these examples show that any programming-language is possible.
+
+The [RAML Module Builder](https://github.com/folio-org/raml-module-builder) (RMB) framework, is a special module that abstracts much functionality and enables the developer to focus on implementing business functions. Define the APIs and objects in RAML files and schema files, then the RMB generates code and provides tools to help implement the module.
+(Note that at this stage of the FOLIO project, only this Java-based framework is available.)

--- a/doc/primer-develop-frontend.md
+++ b/doc/primer-develop-frontend.md
@@ -12,3 +12,5 @@ Eventually go via the foundation described in
 [The Stripes Module Developer's Guide](https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md)
 to
 [Skeleton module](https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md#skeleton-module).
+
+The [Regression tests for FOLIO UI](https://github.com/folio-org/ui-testing) will assist.

--- a/doc/primer-develop-frontend.md
+++ b/doc/primer-develop-frontend.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Primer for frontend development
+title: Primer for front-end development
 ---
 
 Start with introduction to [user interface](/doc/#user-interface)

--- a/source-code/index.md
+++ b/source-code/index.md
@@ -217,6 +217,7 @@ exists and can be run, the APIs are likely to change.
 
 - [ui-testing](https://github.com/folio-org/ui-testing)
   -- Regression tests for FOLIO UI.
+  The testing framework is explained. Guidelines for module developers.
 
 - [folio-org.github.io](https://github.com/folio-org/folio-org.github.io)
   -- The source for this dev.folio.org website.


### PR DESCRIPTION
Add section “Fundamental documentation” and link to the main starting points.

Link to the new “ui-testing” readme doc.
Link to the new “Permissions” doc.
Add basic doc to guide back-end development.