### PR TITLE
FOLIO-672 apidocs sections

### DIFF
--- a/_sass/_folio.scss
+++ b/_sass/_folio.scss
@@ -34,13 +34,13 @@ table.api {
   width: 35em;
 }
 table.api .label {
-  width: 45%;
+  width: 44%;
 }
 table.api .raml {
   width: 35%;
 }
 table.api .view {
-  width: 10%;
+  width: 11%;
 }
 
 :target {

--- a/_sass/_folio.scss
+++ b/_sass/_folio.scss
@@ -29,11 +29,21 @@ th, td {
 th {
   background-color: $f-color-lighter-grey;
 }
+table.api {
+  table-layout: fixed;
+  width: 35em;
+}
+table.api .label {
+  width: 45%;
+}
+table.api .raml {
+  width: 35%;
+}
+table.api .view {
+  width: 10%;
+}
 
 :target {
-  border-left: 5px solid $f-color-orange;
-}
-tr:target td:first-child {
   border-left: 5px solid $f-color-orange;
 }
 

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -21,7 +21,7 @@ access the functionality provided by these important core modules.
 * view-2: Uses one-page view to everything.
 
 {% assign urlAws = "https://s3.amazonaws.com/foliodocs/api" %}
-{% assign urlGithub= "https://github.com/folio-org" %}
+{% assign urlGithub = "https://github.com/folio-org" %}
 
 {% for repo in site.data.api %}
 <h2 id="{{ repo[0] }}"> {{ repo[0] }} </h2>
@@ -35,8 +35,8 @@ access the functionality provided by these important core modules.
     </tr>
   </thead>
   <tbody>
-  {% for docset in repo[1] %}
-    {% for doc in docset.files %}
+  {%- for docset in repo[1] -%}
+    {%- for doc in docset.files -%}
       {% capture urlDoc1 %}{{ urlAws }}/{{ repo[0] }}/{% if docset.label %}{{ docset.label }}/{% endif %}{{ doc }}.html{% endcapture %}
       {% capture urlDoc2 %}{{ urlAws }}/{{ repo[0] }}/{% if docset.label %}{{ docset.label }}/{% endif %}2/{{ doc }}.html{% endcapture %}
       {% capture urlRaml %}{{ urlGithub }}/{{ repo[0] }}/blob/master/{{ docset.directory }}/{{ doc }}.raml{% endcapture %}
@@ -46,8 +46,8 @@ access the functionality provided by these important core modules.
       <td> <a href="{{ urlDoc1 }}">view-1</a> </td>
       <td> <a href="{{ urlDoc2 }}">view-2</a> </td>
     </tr>
-    {% endfor %}
-  {% endfor %}
+    {%- endfor -%}
+  {%- endfor %}
   </tbody>
 </table>
 {% endfor %}

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -10,6 +10,8 @@ menuSubTitle: "API documentation"
 menuSubIndex: 2
 ---
 
+## Introduction
+
 These API specifications are automatically generated from the relevant
 [RAML](https://github.com/folio-org/raml)
 files, and specify how client modules may
@@ -21,50 +23,31 @@ access the functionality provided by these important core modules.
 {% assign urlAws = "https://s3.amazonaws.com/foliodocs/api" %}
 {% assign urlGithub= "https://github.com/folio-org" %}
 
-{% capture arrayStr %}
 {% for repo in site.data.api %}
-  {% assign groupSize = 0 %}
-  {% for docset in repo[1] %}
-    {% assign groupSize = groupSize | plus: docset.files.size %}
-  {% endfor %}
-  {{ groupSize }}#
-{% endfor %}
-{% endcapture %}
-{% assign groupSizes = arrayStr | split: "#" %}
-
-<table>
+<h2 id="{{ repo[0] }}"> {{ repo[0] }} </h2>
+<table class="api">
   <thead>
     <tr>
-      <th title="Module">Module</th>
-      <th title="Label">Label</th>
-      <th title="APIs and link to RAML source">APIs</th>
-      <th title="View 1: using raml2html">view-1</th>
-      <th title="View 2: using raml-fleece">view-2</th>
+      <th class="label" title="Label">Label</th>
+      <th class="raml" title="APIs and link to RAML source">APIs</th>
+      <th class="view" title="View 1: using raml2html">view-1</th>
+      <th class="view" title="View 2: using raml-fleece">view-2</th>
     </tr>
   </thead>
   <tbody>
-  {% for repo in site.data.api %}
-    {% capture groupSpan %}{{ groupSizes[forloop.index0] }}{% endcapture %}
-    {% assign itemNum = 0 %}
-    {% for docset in repo[1] %}
-      {% for doc in docset.files %}
-        {% assign itemNum = itemNum | plus: 1 %}
-        {% capture rowId %}{{ repo[0] }}_{% if docset.label %}{{ docset.label }}{% endif %}_{{ forloop.index }}{% endcapture %}
-        {% capture urlDoc1 %}{{ urlAws }}/{{ repo[0] }}/{% if docset.label %}{{ docset.label }}/{% endif %}{{ doc }}{% endcapture %}
-        {% capture urlDoc2 %}{{ urlAws }}/{{ repo[0] }}/{% if docset.label %}{{ docset.label }}/{% endif %}2/{{ doc }}{% endcapture %}
-        <tr id="{{ rowId }}">
-          {% if itemNum == 1 %}
-          <td id="{{ repo[0] }}" rowspan="{{ groupSpan }}"> {{ repo[0] }} </td>
-          {% endif %}
-          <td> {{ docset.label }}</td>
-          <td>
-            <a href="{{ urlGithub }}/{{ repo[0] }}/blob/master/{{ docset.directory }}/{{ doc }}.raml"> {{ doc }}</a>
-          </td>
-          <td><a href="{{ urlDoc1 }}.html">view-1</a></td>
-          <td><a href="{{ urlDoc2 }}.html">view-2</a></td>
-        </tr>
-      {% endfor %}
+  {% for docset in repo[1] %}
+    {% for doc in docset.files %}
+      {% capture urlDoc1 %}{{ urlAws }}/{{ repo[0] }}/{% if docset.label %}{{ docset.label }}/{% endif %}{{ doc }}.html{% endcapture %}
+      {% capture urlDoc2 %}{{ urlAws }}/{{ repo[0] }}/{% if docset.label %}{{ docset.label }}/{% endif %}2/{{ doc }}.html{% endcapture %}
+      {% capture urlRaml %}{{ urlGithub }}/{{ repo[0] }}/blob/master/{{ docset.directory }}/{{ doc }}.raml{% endcapture %}
+    <tr>
+      <td> {{ docset.label }} </td>
+      <td> <a href="{{ urlRaml }}">{{ doc }}</a> </td>
+      <td> <a href="{{ urlDoc1 }}">view-1</a> </td>
+      <td> <a href="{{ urlDoc2 }}">view-2</a> </td>
+    </tr>
     {% endfor %}
   {% endfor %}
   </tbody>
 </table>
+{% endfor %}


### PR DESCRIPTION
Use page sections rather than one big table. Each repo has a section with its own table.
Preparing for upcoming in-page table-of-contents.
It is a lot neater, and simpler Liquid code.