### PR TITLE
FOLIO-1058 improve page titles

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,8 +1,17 @@
-{% capture this_page_title %}
-{% if page.url == '/' or page.title == nil %} {{ site.title }}
-{% else %} {{ page.title | prepend: ' | ' | prepend: site.title }}
-{% endif %}
-{% endcapture %}
+{%- assign areas = page.url | split:'/' -%}
+{%- assign len = areas.size | minus: 2 -%}
+{%- capture leader -%}
+  {%- if page.titleLeader -%}
+    {{ page.titleLeader }}
+  {%- else -%}
+    {% for i in (1..len) %}{{ areas[i] | capitalize }} | {% endfor %}
+  {%- endif -%}
+{%- endcapture -%}
+{%- capture this_page_title -%}
+{%- if page.url == '/' or page.title == nil -%} {{ site.title }}
+{%- else -%} {{ site.title }} | {{ leader }} {{ page.title }}
+{%- endif -%}
+{%- endcapture -%}
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/doc/primer-develop-backend.md
+++ b/doc/primer-develop-backend.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Primer for back-end development
-permalink: /doc//primer-develop-backend/
+permalink: /doc/primer-develop-backend/
 menuInclude: no
 menuTopTitle: Documentation
 ---

--- a/search-other.md
+++ b/search-other.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Other search and report facilities
+titleLeader: "Search |"
 permalink: /search-other/
 menuInclude: yes
 menuLink: yes

--- a/search_data.json
+++ b/search_data.json
@@ -11,9 +11,18 @@ layout: null
     {%- if docId == "banner-area-html" -%}{%- continue -%}{%- endif -%}
     {%- if docId == "feed-xml" -%}{%- continue -%}{%- endif -%}
     {%- if docId == "about" -%}{%- continue -%}{%- endif -%}
+    {%- assign areas = page.url | split:'/' -%}
+    {%- assign len = areas.size | minus: 2 -%}
+    {%- capture leader -%}
+      {%- if page.titleLeader -%}
+        {{ page.titleLeader | append:' ' }}
+      {%- else -%} 
+        {% for i in (1..len) %}{{ areas[i] | capitalize }} | {% endfor %}
+      {%- endif -%}
+    {%- endcapture -%}
     {
       "id": "{{ docId }}",
-      "title": "{{ page.title | xml_escape }}",
+      "title": "{{ leader | remove:'Doc |' }}{{ page.title | xml_escape }}",
       "content": "{{ page.content | strip_html | escape | remove: '\' |  split: ' ' | join: ' ' }}",
       "url": "{{ page.url | xml_escape | remove: '.html' }}",
       "author": "{{ page.author | xml_escape }}",


### PR DESCRIPTION
If a page's frontmatter has "titleLeader" then use that, otherwise
convert each directory name in the URL to a word.