### PR TITLE
FOLIO-1116 jenkins release jobs

### DIFF
--- a/guidelines/release-procedures.md
+++ b/guidelines/release-procedures.md
@@ -144,8 +144,11 @@ An 'artifact' in this context could either be a Maven artifact released to the F
 Maven repository, a docker image released to Docker Hub, a Linux distribution package
 or some combination of artifacts depending on the project.
 
-To release the artifacts
-relevant to your project, connect to the [FOLIO Jenkins system](https://jenkins-aws.indexdata.com).
+The remainder of this section applies only to the Okapi and RMB projects.
+For all other backend modules the artifact releases are triggered manually from the Tags tab in the GitHub "Releases" section of each project.
+
+For Okapi and RMB, to release the artifacts
+connect to the [FOLIO Jenkins system](https://jenkins-aws.indexdata.com).
 Jenkins credentials utilize the Github authentication for FOLIO core developers, so ensure that you are logged in to GitHub to then enable log in to Jenkins.
 
 Navigate to [https://jenkins-aws.indexdata.com/job/folio-org/](https://jenkins-aws.indexdata.com/job/folio-org/), find your project,
@@ -153,13 +156,6 @@ and select the tab with Tags. Find your version tag, probably at the end of the
 list, and click on it. Or, you can go directly to it via something like
 [https://jenkins-aws.indexdata.com/job/folio-org/job/okapi/view/tags/job/v2.9.4/](https://jenkins-aws.indexdata.com/job/folio-org/job/okapi/view/tags/job/v2.9.4/)
 Click on the "Build Now" in the left side menu.
-
-Some projects still use the old procedure, like this: Navigate to your "My Views > Release Jobs"
-folder and select your module's Jenkins job name with the '-release' suffix.
-For example, 'okapi-release'.   Select 'Build with Parameters' and select the release tag you
-want to release.  This will build the release artifacts and deploy them to the proper
-repositories. (If you do not see the 'Build with Parameters' menu point, check that
-you have logged in! Or if you should be using the new procedure, above)
 
 ### Merge the release branch into master
 Go to GitHub and make a pull request for the release branch you just pushed.

--- a/guides/automation.md
+++ b/guides/automation.md
@@ -74,50 +74,7 @@ So log in to Jenkins as described above, and find the relevant Automation job.
 If you have the permissions to do so, then the job can be initiated.
 
 Another common Jenkins job is dedicated to code releases.
-The following notes are a summary. More detail is at [release procedures](/guidelines/release-procedures/).
-
-For Maven-based projects, the
-[Maven Release Plugin](//maven.apache.org/maven-release/maven-release-plugin)
-is required.  To enable the release plugin, add the following to
-the parent POM of the project:
-
-```xml
-<plugin>
-  <groupId>org.apache.maven.plugins</groupId>
-  <artifactId>maven-release-plugin</artifactId>
-  <version>2.5.3</version>
-  <configuration>
-    <preparationGoals>clean verify</preparationGoals>
-    <tagNameFormat>v@{project.version}</tagNameFormat>
-    <pushChanges>false</pushChanges>
-    <localCheckout>true</localCheckout>
-  </configuration>
-</plugin>
-```
-
-These jobs are initiated manually and parameterized.  The two primary parameters
-are the release version and the next development version.
-
-```
-mvn release:clean release:prepare release:perform \
-  -DreleaseVersion=${releaseVersion} -DdevelopmentVersion=${developmentVersion}
-```
-
-Together, Jenkins and Maven perform roughly the following steps to coordinate a release:
-
-* Local 'git checkout' of the master branch of the project from GitHub.
-* Check that there are no SNAPSHOT dependencies.
-* Run build and unit tests on current branch to ensure build is stable.
-* Update parent and child POMs to $releaseVersion, tag the release, make local commits.
-* Update parent and child POMs to $developmentVersion and locally commit.
-* Local git checkout of release tag, and perform release build and deploy Maven artifacts
-  to Maven release repository (if specified).
-* Run any post-build steps such as building and publishing Docker images and running
-  additional integration tests.
-* If all build and post-build steps complete successfully, the last step is to have
-  Jenkins push all commits and tags back to the master branch of the project repository
-  on GitHub.  If any part of this process fails, no tags or commits are pushed
-  to the origin repository.
+See [release procedures](/guidelines/release-procedures/).
 
 Other Jenkins automation jobs exist as well for test deployments to AWS EC2 instances.
 


### PR DESCRIPTION
Modify release-related docs to indicate that release artifacts are now initiated via GitHub Release/Tags tab.

See the [build](http://folio-1116-jenkins-release-jobs.dev.folio.org.s3-website-us-east-1.amazonaws.com/guidelines/release-procedures/#build-and-release-artifacts) of this branch.