### PR TITLE
FOLIO-1284 Downgrade jekyll-remote-theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 3.8"
-gem "jekyll-remote-theme"
+gem "jekyll-remote-theme", "0.2.4"
 gem "jekyll-data"
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,9 +52,10 @@ GEM
       jekyll (~> 3.3)
     jekyll-gist (1.5.0)
       octokit (~> 4.2)
-    jekyll-remote-theme (0.3.1)
+    jekyll-remote-theme (0.2.4)
       jekyll (~> 3.5)
       rubyzip (>= 1.2.1, < 3.0)
+      typhoeus (>= 0.7, < 2.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-watch (2.0.0)
@@ -108,7 +109,7 @@ DEPENDENCIES
   jekyll-data
   jekyll-feed (~> 0.6)
   jekyll-gist
-  jekyll-remote-theme
+  jekyll-remote-theme (= 0.2.4)
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
Was v0.3.1 current, now v0.2.4