### PR TITLE
FOLIO-903 Fix api-docs config mod-users-bl

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -25,11 +25,12 @@ mod-users:
 
 mod-users-bl:
   - label: null
-    directory: raml/ramls/mod-users-bl
+    directory: ramls
     files:
       - mod-users-bl
-    ramlutil: null
-    shared: ramls/mod-users-bl
+    excludes:
+      - raml
+    ramlutil: ramls/raml
 
 mod-permissions:
   - label: null


### PR DESCRIPTION
Seems to be experimenting with non-shared configuration for its mod-users-bl pieces.

Has non-standard naming for the git submodule (i.e. ramls/raml rather than ramls/raml-util) so the configuration needs the "excludes" parameter to avoid also processing the RAML files in that area.