### PR TITLE
FOLIO-903 api docs config 30

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -380,24 +380,11 @@ raml:
     files:
       - tenant
     ramlutil: .
-  - label: shared-mod-login
-    directory: ramls/mod-login
-    files:
-      - login
-    ramlutil: .
   - label: shared-mod-permissions
     directory: ramls/mod-permissions
     files:
       - tenantPermissions
       - permissions
-    ramlutil: .
-  - label: shared-mod-users
-    directory: ramls/mod-users
-    files:
-      - groups
-      - users
-      - addressTypes
-      - proxiesFor
     ramlutil: .
   - label: shared-codex
     directory: ramls/codex

--- a/_data/api.yml
+++ b/_data/api.yml
@@ -62,18 +62,10 @@ mod-permissions:
 
 mod-login:
   - label: null
-    directory: raml-util/ramls/mod-login
+    directory: ramls
     files:
       - login
-    ramlutil: null
-    shared: ramls/mod-login
-# 201809: Upcoming new config to replace the above entry
-#mod-login:
-#  - label: null
-#    directory: ramls
-#    files:
-#      - login
-#    ramlutil: ramls/raml-util
+    ramlutil: ramls/raml-util
 
 mod-login-saml:
   - label: null


### PR DESCRIPTION
New config for mod-login

Also removed config in “raml” repo for shared-mod-users and shared-mod-login