### PR TITLE
MODGQL-110 Add property multiple to apidocs config

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -106,6 +106,7 @@ mod-codex-ekb:
     ramlutil: null
     schemasDirectory: ramls/raml-util/schemas/codex
     shared: ramls/codex
+    multiple: true
 
 mod-codex-inventory:
   - label: null
@@ -116,6 +117,7 @@ mod-codex-inventory:
     ramlutil: null
     schemasDirectory: ramls/raml-util/schemas/codex
     shared: ramls/codex
+    multiple: true
 
 mod-codex-mux:
   - label: null
@@ -126,6 +128,17 @@ mod-codex-mux:
     ramlutil: null
     schemasDirectory: ramls/raml-util/schemas/codex
     shared: ramls/codex
+
+mod-codex-mock:
+  - label: null
+    version1: true
+    directory: ramls/raml-util/ramls/codex
+    files:
+      - codex
+    ramlutil: null
+    schemasDirectory: ramls/raml-util/schemas/codex
+    shared: ramls/codex
+    multiple: true
 
 mod-circulation:
   - label: null

--- a/_faqs/how-to-configure-api-doc-generation.md
+++ b/_faqs/how-to-configure-api-doc-generation.md
@@ -87,6 +87,12 @@ This enables the API docs table to exclude the "view-2" column as explained in t
 For some non-standard layouts, the [Describe schema and properties](/guides/describe-schema/) component of the [lint-raml-cop](/guides/raml-cop/) CI job needs to be provided this pathname to the JSON schemas.
 Otherwise it searches under the "ramls" [directory](#directory), which might cause it to discover additional files.
 
+### multiple
+
+To assist mod-graphql to handle interfaceType=multiple rather than reading ModuleDescriptor.
+Set `multiple` to `true` if this module provides the "multiple" interface.
+Default is `false`, or this property can be omitted to denote that.
+
 ### rmb
 
 The default is `true`, or this property can be omitted to denote that.


### PR DESCRIPTION
To assist mod-graphql to handle interfaceType=multiple rather than reading ModuleDescriptor