### PR TITLE
STRIPES-573 Update URLs of moved stripes docs

### DIFF
--- a/_faqs/explain-dates-times.md
+++ b/_faqs/explain-dates-times.md
@@ -9,4 +9,4 @@ faqOrder: 3
 
 Dates and times are stored with the back-end modules as UTC.
 
-The i18n document [explains](https://github.com/folio-org/stripes-core/blob/master/doc/i18n.md#dates-and-times) how they are formatted for display by front-end modules.
+The i18n document [explains](https://github.com/folio-org/stripes/blob/master/doc/i18n.md#dates-and-times) how they are formatted for display by front-end modules.

--- a/_faqs/explain-release-procedures.md
+++ b/_faqs/explain-release-procedures.md
@@ -10,7 +10,7 @@ faqOrder: 1
 The back-end modules follow the general [procedure](/guidelines/release-procedures/).
 
 The front-end modules (i.e. stripes-* and ui-*) follow the
-[Stripes release procedure](https://github.com/folio-org/stripes-core/blob/master/doc/release-procedure.md).
+[Stripes release procedure](https://github.com/folio-org/stripes/blob/master/doc/release-procedure.md).
 
 There are separate notes about the
 [FOLIO version-numbering scheme](/guidelines/contributing#version-numbers).

--- a/_faqs/how-to-test-prior-to-commit.md
+++ b/_faqs/how-to-test-prior-to-commit.md
@@ -25,4 +25,4 @@ along with the ability to run specific tests.
 
 (The deprecated repository ui-testing [Regression tests for FOLIO UI](https://github.com/folio-org/ui-testing) might still be useful while tests and documentation are moved to those places.)
 
-When running local tests, ensure a well-configured Stripes (see [Creating a new development setup for Stripes](https://github.com/folio-org/stripes-core/blob/master/doc/new-development-setup.md)). Ensure an up-to-date [Pre-built Vagrant box](https://github.com/folio-org/folio-ansible/blob/master/doc/index.md).
+When running local tests, ensure a well-configured Stripes (see [Creating a new development setup for Stripes](https://github.com/folio-org/stripes/blob/master/doc/new-development-setup.md)). Ensure an up-to-date [Pre-built Vagrant box](https://github.com/folio-org/folio-ansible/blob/master/doc/index.md).

--- a/guidelines/naming-conventions.md
+++ b/guidelines/naming-conventions.md
@@ -103,7 +103,7 @@ Each release is tagged in git, with a name beginning with `v` and followed by th
 There are long-lived release branches, with a name beginning with `b` and followed by the major and minor version number -- for example, `b2.17`.
 
 See further information for
-[front-end](https://github.com/folio-org/stripes-core/blob/master/doc/release-procedure.md#version-numbers-branches-and-tags)
+[front-end](https://github.com/folio-org/stripes/blob/master/doc/release-procedure.md#version-numbers-branches-and-tags)
 and
 [back-end](/guidelines/release-procedures/#bug-fix-releases)
 modules.

--- a/guidelines/release-procedures.md
+++ b/guidelines/release-procedures.md
@@ -9,7 +9,7 @@ menuTopTitle: Guidelines
 This document summarises the release procedures for FOLIO projects.
 
 * [Maven-based modules](#maven-based-modules)
-* [Stripes and UI modules](https://github.com/folio-org/stripes-core/blob/master/doc/release-procedure.md)
+* [Stripes and UI modules](https://github.com/folio-org/stripes/blob/master/doc/release-procedure.md)
 
 ## Introduction
 
@@ -222,5 +222,5 @@ and edit `guidelines/release-procedures.md`
 ## Stripes-based modules
 
 All Stripes modules (i.e. stripes-* and ui-*) follow the
-[Stripes release procedure](https://github.com/folio-org/stripes-core/blob/master/doc/release-procedure.md).
+[Stripes release procedure](https://github.com/folio-org/stripes/blob/master/doc/release-procedure.md).
 

--- a/guides/code-analysis.md
+++ b/guides/code-analysis.md
@@ -48,7 +48,7 @@ Regarding "Quality Profile" see issue [FOLIO-864](https://issues.folio.org/brows
 
 ## ESLint for client-side projects
 
-The [Code quality](https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md#code-quality)
+The [Code quality](https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#code-quality)
 section of _The Stripes Module Developer's Guide_ explains ESLint usage, how to run it prior to commit, and how to disable some lines.
 
 ## RAML and Schema

--- a/guides/commence-a-module.md
+++ b/guides/commence-a-module.md
@@ -136,7 +136,7 @@ Follow the structure and files of [ui-users](https://github.com/folio-org/ui-use
 
 The [stripes-cli](https://github.com/folio-org/stripes-cli/blob/master/doc/user-guide.md#app-development) will generate an initial skeleton UI app module structure named with the `ui-` prefix.
 
-[The Stripes Module Developer's Guide](https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md) explains what is expected of a UI module.
+[The Stripes Module Developer's Guide](https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md) explains what is expected of a UI module.
 
 The `CHANGELOG.md` lists the main changes for each release. Follow how the other front-end modules use this file.
 
@@ -180,7 +180,7 @@ See [explanation](/guides/jenkinsfile).
 See the "[Stripes application metadata bundles](https://github.com/folio-org/stripes-core/blob/master/doc/app-metadata.md)"
 document which explains the specification for standard and extension fields.
 
-The "Modules" section of the [The Stripes Module Developer's Guide](https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md#modules) explains the `stripes` section of the configuration, including the `pluginType`, the `route` to address this module, the `okapiInterfaces` for any back-end module dependencies, and the optional `permissionsets`.
+The "Modules" section of the [The Stripes Module Developer's Guide](https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#modules) explains the `stripes` section of the configuration, including the `pluginType`, the `route` to address this module, the `okapiInterfaces` for any back-end module dependencies, and the optional `permissionsets`.
 The [Explain the FOLIO permissions system](/faqs/explain-permissions-system/) FAQ will assist.
 
 ## Descriptors {#frontend-end-descriptors}
@@ -231,5 +231,5 @@ As shown in the example listing, the files are within a sub-directory with the s
 
 The various `stripes-components` are separately handled.
 
-See the "[I18n best practices](https://github.com/folio-org/stripes-core/blob/master/doc/i18n.md)" internationalization documentation, and facilities provided by Stripes Core.
+See the "[I18n best practices](https://github.com/folio-org/stripes/blob/master/doc/i18n.md)" internationalization documentation, and facilities provided by Stripes Core.
 

--- a/guides/index.md
+++ b/guides/index.md
@@ -59,7 +59,7 @@ module, especially RAML Module Builder (RMB).
 ## User Interface
 
 The FOLIO user-interface toolkit is called Stripes. It is described in the
-[Stripes Core README](https://github.com/folio-org/stripes-core/blob/master/README.md),
+[Stripes README](https://github.com/folio-org/stripes/blob/master/README.md),
 which leads to the related documentation.
 
 With that background understanding, see the documentation for each

--- a/guides/run-local-folio.md
+++ b/guides/run-local-folio.md
@@ -48,7 +48,7 @@ the [folio-test-env](https://github.com/folio-org/folio-test-env).
 Although these other documents are intended for a production installation, they do have useful parts which assist with running a local system:
 [FOLIO deployment: single server](https://github.com/folio-org/folio-install/blob/master/single-server.md) and [Securing Okapi Installation](https://github.com/folio-org/okapi/blob/master/doc/securing.md).
 
-Follow the [Stripes: quick start](https://github.com/folio-org/stripes-core/blob/master/doc/quick-start.md) for the Stripes UI development server.
+Follow the [Stripes: quick start](https://github.com/folio-org/stripes/blob/master/doc/quick-start.md) for the Stripes UI development server.
 As explained there, the default will use released modules. It can be configured to use your local development versions.
 
 ## Available module versions

--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -11,7 +11,7 @@ Some FOLIO repositories also have specific notes.
 
 ## Other troubleshooting documents
 
-* [Stripes troubleshooting](https://github.com/folio-org/stripes-core/blob/master/doc/troubleshooting.md)
+* [Stripes troubleshooting](https://github.com/folio-org/stripes/blob/master/doc/troubleshooting.md)
 * [Vagrant boxes troubleshooting](https://github.com/folio-org/folio-ansible/blob/master/doc/index.md#troubleshootingknown-issues)
 
 ## Keep system tools up-to-date

--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -29,12 +29,12 @@ the [Okapi Guide and Reference](https://github.com/folio-org/okapi/blob/master/d
 The FOLIO UI toolkit. The Stripes toolkit provides a means of building
 web applications that expose the functionality of underlying Okapi
 modules. For more information, see the
-[Stripes Core GitHub repository](https://github.com/folio-org/stripes-core).
+[Stripes GitHub repository](https://github.com/folio-org/stripes).
 
 ### Stripes entities
 
 The document
-[Stripes entities: packages, modules, apps and more](https://github.com/folio-org/stripes-core/blob/master/doc/modules-apps-etc.md)
+[Stripes entities: packages, modules, apps and more](https://github.com/folio-org/stripes/blob/master/doc/modules-apps-etc.md)
 is a summary of terms used in that context, e.g. component, package, module, app, plugin.
 
 ### Platform, LSP Base, LSP Extended

--- a/search-other.md
+++ b/search-other.md
@@ -25,7 +25,7 @@ Some example searches at GitHub:
 * [Open pull requests for all repositories](https://github.com/search?q=org%3Afolio-org+is%3Apr+is%3Aopen)
 * [Pull requests not yet reviewed for all repositories](https://github.com/search?q=org%3Afolio-org+is%3Apr+is%3Aopen+review%3Anone)
 * [Search Markdown documents in all repositories](https://github.com/search?type=code&amp;q=RMB+org%3Afolio-org+language%3Amarkdown) for term: RMB
-* [Search Markdown documents in stripes-core](https://github.com/search?type=code&amp;q=smart+component+repo%3Afolio-org/stripes-core+language%3Amarkdown) for term: smart component
+* [Search Markdown documents in stripes](https://github.com/search?type=code&amp;q=smart+component+repo%3Afolio-org/stripes+language%3Amarkdown) for term: smart component
 
 Refer to specific
 [GitHub search help](https://help.github.com/categories/searching-for-information-on-github).

--- a/source-code/index.md
+++ b/source-code/index.md
@@ -255,18 +255,17 @@ services and wrapping UI functionality into convenient modules. We
 envisage that most FOLIO UI work will be done in the context of
 Stripes.
 
-The stripes-core [documentation roadmap](https://github.com/folio-org/stripes-core#documentation-roadmap) is the starting point.
+The stripes [documentation](https://github.com/folio-org/stripes/blob/master/README.md) is the starting point.
 Each module has its own documentation.
 
 Note that Stripes is still in the design phase, so although code
 exists and can be run, the APIs are likely to change.
 
 - [stripes](https://github.com/folio-org/stripes)
-  -- The Stripes Framework.
+  -- The Stripes Framework. Includes extensive documentation.
 
 - [stripes-core](https://github.com/folio-org/stripes-core)
   -- The core of the Stripes/UI framework.
-  Includes extensive documentation.
 
 - [stripes-components](https://github.com/folio-org/stripes-components)
   -- A component library for Stripes.

--- a/start/index.md
+++ b/start/index.md
@@ -27,10 +27,10 @@ Bearing in mind that [FOLIO uses any programming language](/guides/any-programmi
 - [RAML Module Builder](https://github.com/folio-org/raml-module-builder) (RMB) framework.
 - Each [server-side](/source-code/#server-side) and [client-side](/source-code/#client-side)
 module's own documentation.
-- [Stripes Core README](https://github.com/folio-org/stripes-core/blob/master/README.md)
+- [Stripes README](https://github.com/folio-org/stripes/blob/master/README.md)
 guides to all front-end documentation.
-- [Stripes entities: packages, modules, apps and more](https://github.com/folio-org/stripes-core/blob/master/doc/modules-apps-etc.md).
-- [The Stripes Module Developer's Guide](https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md)
+- [Stripes entities: packages, modules, apps and more](https://github.com/folio-org/stripes/blob/master/doc/modules-apps-etc.md).
+- [The Stripes Module Developer's Guide](https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md)
 for those writing UI modules for Stripes.
 - [How to run tests prior to commit](/faqs/how-to-test-prior-to-commit/)
 The testing framework is explained. Guidelines for module developers.

--- a/start/overview.md
+++ b/start/overview.md
@@ -91,14 +91,14 @@ The related [Securing Okapi](https://github.com/folio-org/okapi/blob/master/doc/
 used in various documentation as a back-end exemplar.
 Also its run.sh script to run a basic local system.
 
-[Stripes Core](https://github.com/folio-org/stripes-core/blob/master/README.md).
-Its "Documentation roadmap" links to other related Stripes and UI development documentation.
+[Stripes](https://github.com/folio-org/stripes/blob/master/README.md).
+It contains links to other related Stripes and UI development documentation.
 
-[Stripes entities: packages, modules, apps and more](https://github.com/folio-org/stripes-core/blob/master/doc/modules-apps-etc.md).
+[Stripes entities: packages, modules, apps and more](https://github.com/folio-org/stripes/blob/master/doc/modules-apps-etc.md).
 
-[The Stripes Module Developer's Guide](https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md).
+[The Stripes Module Developer's Guide](https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md).
 
-[Stripes: quick start](https://github.com/folio-org/stripes-core/blob/master/doc/quick-start.md).
+[Stripes: quick start](https://github.com/folio-org/stripes/blob/master/doc/quick-start.md).
 
 [Stripes CLI](https://github.com/folio-org/stripes-cli)
 and its [Stripes CLI User Guide](https://github.com/folio-org/stripes-cli/blob/master/doc/user-guide.md).

--- a/start/primer-develop-frontend.md
+++ b/start/primer-develop-frontend.md
@@ -11,12 +11,12 @@ menuSubIndex: 4
 Start with introduction to [user interface](/guides/#user-interface)
 and the [client-side](/source-code/#client-side) source code repositories.
 
-That leads to the Stripes [Documentation Roadmap](https://github.com/folio-org/stripes-core/blob/master/README.md#documentation-roadmap) and overview of the main docs, and necessary background understanding.
+That leads to the Stripes [documentation](https://github.com/folio-org/stripes/blob/master/README.md) and overview of the main docs, and necessary background understanding.
 
 The foundation described in
-[The Stripes Module Developer's Guide](https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md) is necessary for developing UI modules using Stripes.
+[The Stripes Module Developer's Guide](https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md) is necessary for developing UI modules using Stripes.
 
-Then follow [Creating a new development setup for Stripes](https://github.com/folio-org/stripes-core/blob/master/doc/new-development-setup.md) and the [Stripes: quick start](https://github.com/folio-org/stripes-core/blob/master/doc/quick-start.md) and the guide to [Running a local FOLIO system](/guides/run-local-folio/) for guidance to establish your local FOLIO work environment.
+Then follow [Creating a new development setup for Stripes](https://github.com/folio-org/stripes/blob/master/doc/new-development-setup.md) and the [Stripes: quick start](https://github.com/folio-org/stripes/blob/master/doc/quick-start.md) and the guide to [Running a local FOLIO system](/guides/run-local-folio/) for guidance to establish your local FOLIO work environment.
 
 Then move on to creating a real module with the help of [stripes-cli](https://github.com/folio-org/stripes-cli)
 and in particular the [App development](https://github.com/folio-org/stripes-cli/blob/master/doc/user-guide.md#app-development) section.


### PR DESCRIPTION
This updates URLs to several `stripes-core` documents that have been moved to `stripes`.