### PR TITLE
FOLIO-1598 Remove note out-of-date raml-util

### DIFF
--- a/reference/api/index.md
+++ b/reference/api/index.md
@@ -76,8 +76,6 @@ See [usage notes](#usage-notes) below.
 </table>
 {% endfor %}
 
-**NOTE:** 2018-10-24: That last set of generated documents are old. Jenkins needs to be [re-instated](https://issues.folio.org/browse/FOLIO-1598) on the default branch to generate these docs.
-
 ## Further information
 
 ### Configuration {#configure-api-docs}


### PR DESCRIPTION
The generate-api-docs is now operating again for the default (now "raml1.0") branch.