### PR TITLE
FOLIO-903 Config apidocs mod-permissions

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -523,16 +523,6 @@ raml:
     ramlutil: .
     schemasDirectory: schemas
     shared: ramls
-  - label: shared-mod-permissions
-    version1: true
-    directory: ramls/mod-permissions
-    files:
-      - tenantPermissions
-      - permissions
-    ramlutil: .
-    schemasDirectory: schemas/mod-permissions
-    shared: ramls/mod-permissions
-    multiple: true
   - label: shared-codex
     version1: true
     directory: ramls/codex


### PR DESCRIPTION
mod-permissions are now not shared.
Moving back to its home repo MODPERMS-48 and MODPERMS-49.
So stop processing them in this shared "ramls" repo.

Other configuration was done in pull #308 