### PR TITLE
Fix htmlproofer verify fragment identifier

### DIFF
--- a/bin/htmlproofer.sh
+++ b/bin/htmlproofer.sh
@@ -5,7 +5,7 @@ set -e
 DEST="_site"
 
 # Comma-separated string of regex patterns
-IGNORE="/dev\.folio\.org/,/localhost:/,/#/"
+IGNORE="/dev\.folio\.org/,/localhost:/"
 
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
@@ -14,6 +14,7 @@ bundle exec jekyll build --trace
 #  --log-level :debug
 time bundle exec htmlproofer ./$DEST \
   --assume-extension \
+  --allow-hash-href \
   --timeframe 6w \
   --url-ignore $IGNORE \
   $@


### PR DESCRIPTION
Use option "--allow-hash-ref" to skip bare "#" hrefs, and so enable real fragment identifiers to be verified.
Had introduced this problem with commit 039c3d2