### PR TITLE
Delete CNAME file to disable GitHub Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-dev.folio.org


### PR DESCRIPTION
Hopefully this will remove the GitHub Pages functionality.  If not, the recommended path forward appears to be "deleting the master branch" ([docs](https://help.github.com/en/articles/unpublishing-a-project-pages-site)).