### PR TITLE
FOLIO-2251 Deprecate mod-kb-ebsco ruby

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -266,15 +266,6 @@ mod-invoice-storage:
     ramlutil: ramls/raml-util
     schemasDirectory: ramls/acq-models/mod-invoice-storage/schemas
 
-mod-kb-ebsco:
-  - label: null
-    version1: true
-    directory: ramls
-    files:
-      - eholdings
-    ramlutil: ramls/raml-util
-    rmb: false
-
 mod-kb-ebsco-java:
   - label: null
     version1: true

--- a/_data/apigroup.yml
+++ b/_data/apigroup.yml
@@ -33,7 +33,6 @@ inventory:
     - mod-circulation-storage
     - mod-inventory
     - mod-inventory-storage
-    - mod-kb-ebsco
     - mod-kb-ebsco-java
     - mod-oai-pmh
     - edge-oai-pmh

--- a/source-code/index.md
+++ b/source-code/index.md
@@ -127,9 +127,6 @@ facilitated by the code in the `raml-module-builder` repository.
 - [mod-graphql](https://github.com/folio-org/mod-graphql)
   -- Executing GraphQL queries.
 
-- [mod-kb-ebsco](https://github.com/folio-org/mod-kb-ebsco)
-  -- Broker communication with the EBSCO knowledge base.
-
 - [mod-kb-ebsco-java](https://github.com/folio-org/mod-kb-ebsco-java)
   -- Broker communication with the EBSCO knowledge base.
 


### PR DESCRIPTION
It was renamed to [deprecated-mod-kb-ebsco-ruby](https://github.com/folio-org/deprecated-mod-kb-ebsco-ruby) and then archived