### PR TITLE
Add html id attribute each row of api docs tables

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -800,3 +800,4 @@ mod-vendors:
       - vendor_type
     ramlutil: ramls/raml-util
     schemasDirectory: ramls/acq-models/mod-vendors/schemas
+

--- a/reference/api/index.md
+++ b/reference/api/index.md
@@ -74,10 +74,12 @@ This list of modules is sorted into functional groups.
       {% capture view2 %}{% if docset.version1 %}<a href="{{ urlDoc2 }}">view-2</a>{% endif %}{% endcapture %}
       {% if docset.shared %}
         {% capture urlRaml %}{{ urlGithub }}/raml/blob/HEAD/{{ docset.shared }}/{{ doc }}.raml{% endcapture %}
+        {% capture rowId %}{{ theRepo[0] }}-{{ docset.label }}-{{ doc }}{% endcapture %}
       {% else %}
         {% capture urlRaml %}{{ urlGithub }}/{{ theRepo[0] }}/blob/master/{{ docset.directory }}/{{ doc }}.raml{% endcapture %}
+        {% capture rowId %}{{ theRepo[0] }}-{{ doc }}{% endcapture %}
       {% endif %}
-    <tr>
+    <tr id="{{ rowId }}">
 {% if theRepo[0] == 'raml' %}
       <td> {{ docset.label }} </td>
 {% endif %}


### PR DESCRIPTION
For example:
https://dev.folio.org/reference/api/#mod-notes-types