### PR TITLE
FOLIO-903 Config apidocs mod-finance

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -402,6 +402,7 @@ mod-finance:
       - budgets
       - exchange-rate
       - expense-classes
+      - finance-fund-codes-expense-classes
       - fiscal-years
       - fund-types
       - funds


### PR DESCRIPTION
**Attention**:
Would mod-finance please migrate to use:
https://dev.folio.org/reference/api/#explain-api-doc
https://dev.folio.org/reference/api/#explain-api-lint
The tools that you are using were deprecated long ago.