### PR TITLE
FOLIO-3231 List repos that are missing api-doc

### DIFF
--- a/_data/api-missing.yml
+++ b/_data/api-missing.yml
@@ -1,0 +1,13 @@
+# List of repos that have API descriptions, but not yet configured api-doc.
+# FOLIO-3231
+---
+edge-caiasoft:
+edge-dematic:
+edge-inn-reach:
+edge-search-srs:
+folio-spring-base:
+mod-data-export-spring:
+mod-data-export-worker:
+mod-ebsconet:
+mod-remote-storage:
+mod-translations:

--- a/reference/api/index.md
+++ b/reference/api/index.md
@@ -149,6 +149,15 @@ This list of modules is sorted into functional groups.
   {% endfor %}
 {% endfor %}
 
+## Missing API documentation
+
+The following list of modules are missing the configuration for generating their API documentation.
+
+{% for moduleId in site.data.api-missing %}
+<h3 id="{{ moduleId }}"> {{ moduleId }} </h3>
+<p class="attention note-small-2"> Module should be using "<a href="#explain-api-doc">api-doc</a>" CI facilty. </p>
+{% endfor %}
+
 ## Further information
 
 ### Usage notes


### PR DESCRIPTION
Add a list of new (mostly OAS) modules that are missing the configuration for generating and publishing their API documentation.
https://dev.folio.org/reference/api/#missing-api-documentation