### PR TITLE
FOLIO-903 Config apidocs mod-inventory-storage

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -231,6 +231,7 @@ mod-inventory-storage:
       - inventory-view
       - item-damaged-statuses
       - item-storage
+      - item-storage-dereferenced
       - item-sync
       - item-note-type
       - alternative-title-type


### PR DESCRIPTION
**Attention**:
Would mod-inventory-storage please migrate to use:
https://dev.folio.org/reference/api/#explain-api-doc
https://dev.folio.org/reference/api/#explain-api-lint
The tools that you are using were deprecated long ago.