### PR TITLE
FOLIO-903 Config apidocs mod-inventory-storage

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -217,6 +217,7 @@ mod-inventory-storage:
       - holdings-type
       - holdings-note-type
       - hrid-settings-storage
+      - instance-iteration
       - instance-preceding-succeeding-titles
       - instance-reindex
       - instance-storage


### PR DESCRIPTION
**Attention**:
Would mod-inventory-storage please migrate to use:
https://dev.folio.org/reference/api/#explain-api-doc
https://dev.folio.org/reference/api/#explain-api-lint
The tools that you are using were deprecated long ago.