### PR TITLE
FOLIO-903 Config apidocs mod-inventory-storage

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -211,6 +211,7 @@ mod-inventory-storage:
     directory: ramls
     files:
       - authorities
+      - authorities-reindex
       - authority-note-type
       - bound-with-part
       - holdings-sources


### PR DESCRIPTION
Attention:
Would mod-inventory-storage please migrate to use:
https://dev.folio.org/reference/api/#explain-api-doc
https://dev.folio.org/reference/api/#explain-api-lint
The tools that you are using were deprecated long ago.