### PR TITLE
FOLIO-903 Config apidocs mod-erm-usage-harvester

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -362,7 +362,6 @@ mod-erm-usage-harvester:
     files:
       - harvester
       - periodic
-      - start
     ramlutil: ramls/raml-util
 
 mod-finc-config:


### PR DESCRIPTION
**Attention**:
Would mod-erm-usage-harvester please migrate to use:
https://dev.folio.org/reference/api/#explain-api-doc
https://dev.folio.org/reference/api/#explain-api-lint
The CI tools that you are using were deprecated long ago.
