### PR TITLE
list-repos-api without docker container

### DIFF
--- a/.github/workflows/list-repos-api.yml
+++ b/.github/workflows/list-repos-api.yml
@@ -8,6 +8,7 @@ on:
     branches: [ master ]
     paths:
       - '_data/repos.json'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -17,6 +18,4 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Extract repo names
-      uses: awesome-global-contributions/action-yq@v1.0.2
-      with:
-        file: .github/workflows/list-repos-api.sh
+      run: .github/workflows/list-repos-api.sh


### PR DESCRIPTION
Running list-repos-api.sh on the docker container provided by
https://github.com/awesome-global-contributions/action-yq
takes 23 seconds, while running it directly on GitHub Action's
ubuntu-latest only takes 1 second.

ubuntu-latest comes with all required dependencies pre-installed:
https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md