### PR TITLE
Prevent path traversal vulnerability (CWE-23)

### DIFF
--- a/.github/workflows/gather-schema-changes.yml
+++ b/.github/workflows/gather-schema-changes.yml
@@ -7,6 +7,7 @@ name: gather-schema-changes
 on:
   schedule:
     - cron: '20 03 * * 1,4'
+  workflow_dispatch:
 
 jobs:
   job_1:

--- a/.github/workflows/gather-schema-changes/requirements.txt
+++ b/.github/workflows/gather-schema-changes/requirements.txt
@@ -1,3 +1,4 @@
 requests
 sh
 PyYAML
+Werkzeug


### PR DESCRIPTION
Call `secure_filename` before passing a filename to `open`, `os.walk` or `shutil.copytree`.
Components of the filename come from an external JSON fetched from a URL. This may result in a path traversal vulnerability: https://cwe.mitre.org/data/definitions/23.html Security scanners like snyk.io report that this code might be vulnerable.
The risk may be low, however, fixing the code is less effort than the reviews that the FOLIO security team needs to do on gather_schema_changes.py every 30 days. Safety first!