### PR TITLE
nokogiri 1.13.3 fixing CVE-2021-30560, CVE-2022-23308

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,14 +4,14 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     ethon (0.15.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    faraday (1.9.3)
+    faraday (1.10.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -45,9 +45,9 @@ GEM
       typhoeus (~> 1.3)
       yell (~> 2.0)
     http_parser.rb (0.8.0)
-    i18n (1.8.11)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    jekyll (4.2.1)
+    jekyll (4.2.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -73,11 +73,11 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
       rubyzip (>= 1.3.0, < 3.0)
-    jekyll-sass-converter (2.1.0)
+    jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.1)
+    kramdown (2.3.2)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -86,29 +86,23 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    mini_portile2 (2.7.1)
     multipart-post (2.1.1)
-    nokogiri (1.13.1)
-      mini_portile2 (~> 2.7.0)
-      racc (~> 1.4)
-    nokogiri (1.13.1-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.1-x86_64-linux)
+    nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     octokit (4.22.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    parallel (1.21.0)
+    parallel (1.22.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
     racc (1.6.0)
     rainbow (3.1.1)
-    rb-fsevent (0.11.0)
+    rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
-    rouge (3.27.0)
+    rouge (3.28.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
@@ -125,9 +119,7 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
-  ruby
-  x86_64-darwin-19
-  x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   html-proofer
@@ -139,4 +131,4 @@ DEPENDENCIES
   kramdown-parser-gfm
 
 BUNDLED WITH
-   2.2.29
+   2.3.10

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ to use the [Jekyll Docker image](https://github.com/envygeeks/jekyll-docker).
 
 Our Gemfile defines the version of Jekyll that we use.
 
+## Updating dependencies
+
+Update the pinned dependency versions in Gemfile.lock by running
+`docker run --rm --volume="$PWD:/srv/jekyll" -it jekyll/jekyll:latest bundle update`
+
 ## Local development
 
 To view and edit documents on your local machine, run the local Jekyll server:


### PR DESCRIPTION
Update nokogiri from 1.13.1 to 1.13.3. This fixes
* https://github.com/advisories/GHSA-fq42-c5rg-92c2
* https://nvd.nist.gov/vuln/detail/CVE-2021-30560
* https://nvd.nist.gov/vuln/detail/CVE-2022-23308

Also update all other dependencies in Gemfile.lock.