### PR TITLE
Add guides section: Module development bases

### DIFF
--- a/guides/folio-vertx-lib.md
+++ b/guides/folio-vertx-lib.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: FOLIO Vert.x library for module development
+permalink: /guides/folio-vertx-lib/
+menuInclude: no
+menuTopTitle: Guides
+---
+
+## Introduction
+
+The [FOLIO Vert.x library](https://github.com/folio-org/folio-vertx-lib) is a lightweight FOLIO module development library for Vert.x that supports OpenAPI ([OAS](/start/primer-oas/)). It is the recommended library for development of FOLIO modules with [Vert.x OpenAPI](https://vertx.io/docs/vertx-web-openapi/java/).
+
+The library provides utilities such as:
+
+* OpenAPI support
+* Tenant API 2.0 support
+* PostgreSQL utilities
+* CQL support
+
+## Modules using folio-vertx-lib
+
+Some FOLIO modules that use this library:
+
+* [mod-auth-token](https://github.com/folio-org/mod-authtoken)
+* [mod-eusage-reports](https://github.com/folio-org/mod-eusage-reports)
+* [mod-meta-storage](https://github.com/folio-org/mod-meta-storage)
+
+## Further documentation
+
+Refer to the [folio-vertx-lib README](https://github.com/folio-org/folio-vertx-lib) and [starter example](https://github.com/folio-org/folio-vertx-lib/tree/master/example).
+
+<div class="folio-spacer-content"></div>
+

--- a/guides/index.md
+++ b/guides/index.md
@@ -68,6 +68,7 @@ module, especially the "ui-users".
 * [Getting started](#getting-started)
 * [Reference documentation](#reference-documentation)
 * [Fundamental documentation](#fundamental-documentation)
+* [Module development bases](#module-development-bases)
 * [Development tips](#development-tips)
 * [Tutorials](#tutorials)
 * [Development management](#development-management)
@@ -109,6 +110,24 @@ Refer to the [Start](/start/) section.
 ### Fundamental documentation
 
 These are listed in the [Start](/start/) section.
+
+### Module development bases
+
+There are various libraries and frameworks that provide the basis for module development.
+
+#### Front-end module basis
+
+FOLIO Stripes is the basis for front-end module development. This is introduced at the [Primer for front-end development](/start/primer-develop-frontend/).
+
+#### Back-end module bases
+
+For back-end module development there are various options. These are introduced at the [Primer for back-end development](/start/primer-develop-backend/).
+
+Some more detail is provided via other introductory documentation:
+
+* The [Spring Way](/guides/spring-way/) is the recommended approach for development of FOLIO modules using the Spring framework and Spring projects and OpenAPI ([OAS](/start/primer-oas/)).
+* The [FOLIO Vert.x library](/guides/folio-vertx-lib/) is a lightweight FOLIO module development library for Vert.x that supports OpenAPI ([OAS](/start/primer-oas/)). It is the recommended library for development of FOLIO modules with Vert.x OpenAPI.
+* The [RAML Module Builder](https://github.com/folio-org/raml-module-builder) (RMB) framework, is a special FOLIO module using [RAML](/start/primer-raml/) that abstracts much functionality and enables the developer to focus on implementing business functions. It also exposes a Vert.x based runtime library. **Note**: RAML Module Builder is no longer being extended with new functionality and is in maintenance mode only.
 
 ### Development tips
 


### PR DESCRIPTION
Adds new section https://dev.folio.org/guides/#module-development-bases to introduce libraries and frameworks and approaches that form the basis for module development.