### PR TITLE
Add webrick for Ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "jekyll", "~> 4.2"
 gem "jekyll-remote-theme"
 gem "jekyll-data"
 gem "jekyll-feed"
+gem "webrick"
 # nokogiri is required by html-proofer.
 # If we get a security alert, but not updated upstream, then declare it here.
 # gem "nokogiri", ">= 1.13.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,12 +69,12 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     mini_portile2 (2.8.0)
-    nokogiri (1.13.8)
+    nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-darwin)
+    nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-linux)
+    nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -119,6 +119,7 @@ DEPENDENCIES
   jekyll-feed
   jekyll-gist
   jekyll-remote-theme
+  nokogiri (>= 1.13.9)
   webrick
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     unicode-display_width (1.8.0)
+    webrick (1.7.0)
     yell (2.2.2)
     zeitwerk (2.6.1)
 
@@ -118,6 +119,7 @@ DEPENDENCIES
   jekyll-feed
   jekyll-gist
   jekyll-remote-theme
+  webrick
 
 BUNDLED WITH
    2.3.10


### PR DESCRIPTION
Quote from https://jekyllrb.com/docs/ :
"If you are using Ruby version 3.0.0 or higher, [...] fix it by adding webrick to your dependencies"