### PR TITLE
nokogiri 1.13.9 fixing libxml2 vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "jekyll-data"
 gem "jekyll-feed"
 # nokogiri is required by html-proofer.
 # If we get a security alert, but not updated upstream, then declare it here.
-# gem "nokogiri", ">= 1.13.8"
+gem "nokogiri", ">= 1.13.9"
 
 group :jekyll_plugins do
   gem "html-proofer"


### PR DESCRIPTION
Nokogiri v1.13.9 upgrades the packaged version of its dependency libxml2 to v2.10.3 from v2.9.14.

libxml2 v2.10.3 addresses the following known vulnerabilities:

* CVE-2022-2309 = https://nvd.nist.gov/vuln/detail/CVE-2022-2309
* CVE-2022-40303 = https://nvd.nist.gov/vuln/detail/CVE-2022-40303
* CVE-2022-40304 = https://nvd.nist.gov/vuln/detail/CVE-2022-40304

For details see https://github.com/advisories/GHSA-2qc6-mcvw-92cw