### PR TITLE
Ongoing config apidocs

### DIFF
--- a/_data/config-apidocs.json
+++ b/_data/config-apidocs.json
@@ -1069,7 +1069,7 @@
       "apiTypes": [
         "OAS"
       ],
-      "generator": "api_doc.py 1.4.1"
+      "generator": "api_doc.py 1.4.2"
     },
     "name": "mod-notes",
     "org": "folio-org"


### PR DESCRIPTION
No, a test also failed. It is a problem with the dependency action `repo-sync/pull-request` (which had a new release today) for our pr-config-apidocs.yml and pr-release-versions.yml workflows.

Will disable our Workflows gather-config-apidocs.yml and get-release-versions.yml which will trigger those PR Workflows if there are changes.
