### PR TITLE
Fix source-code map and gather-config-apidocs

### DIFF
--- a/.github/workflows/gather-config-apidocs/gather_config_apidocs.py
+++ b/.github/workflows/gather-config-apidocs/gather_config_apidocs.py
@@ -198,7 +198,7 @@ def report_summary(json_apidocs, json_old_config):
 def list_api_modules(json_repos):
     """Produce a list of API-related modules."""
     list_modules = set()
-    repo_types = ["backend-mod", "backend-edge", "backend-infrastructure", "raml-shared"]
+    repo_types = ["backend-mod", "backend-mgr", "backend-edge", "backend-infrastructure", "raml-shared"]
     for mod in sorted(json_repos["repos"], key=itemgetter('name')):
         if mod["repoType"] in repo_types:
             list_modules.add(mod["name"])

--- a/_data/repos-group.yml
+++ b/_data/repos-group.yml
@@ -14,6 +14,9 @@ stripes:
 platform:
   title: Stripes platform repos
   stem: platform-
+backend-mgr:
+  title: Backend mgr repos
+  stem: mgr-
 backend-mod:
   title: Backend mod repos
   stem: mod-

--- a/_data/repos.json
+++ b/_data/repos.json
@@ -929,7 +929,7 @@
       "org": "folio-org",
       "ramlDirName": null,
       "repoLanguageHint": "java",
-      "repoType": "backend-mod",
+      "repoType": "backend-mgr",
       "snippetIntro": "<p><code>mgr-applications</code> provides following functionality:</p>",
       "workflows": [
         "api-doc.yml",
@@ -951,7 +951,7 @@
       "org": "folio-org",
       "ramlDirName": null,
       "repoLanguageHint": "java",
-      "repoType": "backend-mod",
+      "repoType": "backend-mgr",
       "snippetIntro": "<p><code>mgr-tenant-entitlements</code> provides following functionality:</p>"
     },
     {
@@ -964,7 +964,7 @@
       "org": "folio-org",
       "ramlDirName": null,
       "repoLanguageHint": "java",
-      "repoType": "backend-mod",
+      "repoType": "backend-mgr",
       "snippetIntro": "<p>For now, <code>mgr-tenants</code> proxies requests to OKAPI's tenant API When any operation will happen on tenant, it will take place on realm in keycloak, also it will send a request to keycloak to retrieve a token and persist in cache for 60s for doing all the stuff related to realm</p>",
       "workflows": [
         "api-doc.yml",


### PR DESCRIPTION
A new type of backend module repository was added (`mgr-*`) contravening the module naming convention `mod-*`

Not sure what it means.

Fix the source-code/map/ and the gather-config-apidocs Workflow.