### PR TITLE
FOLIO-3944 Upgrade Actions for API-related Workflows

### DIFF
--- a/.github/workflows/gather-config-apidocs.yml
+++ b/.github/workflows/gather-config-apidocs.yml
@@ -21,9 +21,9 @@ jobs:
         token: ${{ secrets.PAT_PUSH }}
 
     - name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
         architecture: 'x64'
 
     - name: Install dependencies

--- a/.github/workflows/gather-schema-changes.yml
+++ b/.github/workflows/gather-schema-changes.yml
@@ -25,9 +25,9 @@ jobs:
         go-version: 'stable'
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
         architecture: 'x64'
 
     - name: Install Python dependencies

--- a/.github/workflows/get-release-versions.yml
+++ b/.github/workflows/get-release-versions.yml
@@ -20,9 +20,9 @@ jobs:
         token: ${{ secrets.PAT_PUSH }}
 
     - name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
         architecture: 'x64'
 
     - name: Install dependencies


### PR DESCRIPTION
Keep up-to-date with dependent GitHub Actions. [FOLIO-3944](https://issues.folio.org/browse/FOLIO-3944)