### PR TITLE
Remove outdated advice about JSON API

### DIFF
--- a/guidelines/naming-conventions.md
+++ b/guidelines/naming-conventions.md
@@ -95,8 +95,6 @@ The back-end modules can also provide
 [system interfaces](https://github.com/folio-org/okapi/blob/master/doc/guide.md#system-interfaces).
 These Okapi interface names start with underscore, e.g. the Tenant Interface `_tenant`
 
-[JSON API](https://jsonapi.org/) is de facto standard for defining REST JSON interfaces.
-
 ## API endpoints
 
 The back-end modules define their routes and API endpoints in their [API descriptions](/reference/api/),


### PR DESCRIPTION
During a recent review of the TC's module evaluation process, it was recommended that the policy link to the naming guidelines

As part of reviewing those recommendations, I raised [concerns](https://github.com/folio-org/tech-council/pull/55/files#r1472625295) about outdated advice around JSON API

This pull request removes that advice

