### PR TITLE
Fix source-code map alphabeticiser

### DIFF
--- a/source-code/map.md
+++ b/source-code/map.md
@@ -86,6 +86,9 @@ See [usage notes](#usage-notes) below.
       {%- assign sectionChar = headingIds[subSectionNum] | slice:-1,1 | upcase -%}
       {%- assign repoNameAlpha = repoName | remove_first:groupStem -%}
       {%- assign repoNameChar = repoNameAlpha | slice:0 | upcase -%}
+      {%- if repoName == "stripes" -%}
+        {%- assign repoNameChar = "A" -%}
+      {%- endif -%}
       {%- assign charNum = 0 -%}
       {%- for char in alpha -%}
         {%- if char == sectionChar -%}


### PR DESCRIPTION
Because stripes repoName did not contain a dash, the ToC sorting into alpha groups was broken for all stripes repos.

https://dev.folio.org/source-code/map/#stripes