### PR TITLE
FOLIO-3678 Denote missing api-doc mod-mosaic

### DIFF
--- a/_data/api-missing.yml
+++ b/_data/api-missing.yml
@@ -4,5 +4,6 @@
 edge-inventory:
 edge-users:
 mod-camunda:
+mod-mosaic:
 mod-translations:
 mod-workflow:


### PR DESCRIPTION
Their api-lint Workflow reports brokenness, but is not being resolved. Hence when api-doc attempts to build docs on merge to mainline, it cannot.