### PR TITLE
SECURITY-387: Upgrade rexml from 3.4.1 to 3.4.4 fixing CVE-2025-58767

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.4.1)
+    rexml (3.4.4)
     rouge (4.6.0)
     ruby-rc4 (0.1.5)
     rubyzip (2.4.1)


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/SECURITY-387

https://github.com/advisories/GHSA-c2f4-jgmc-q2r5

The REXML gems from 3.3.3 to 3.4.1 have a DoS vulnerability when parsing XML containing multiple XML declarations. If you need to parse untrusted XMLs, you may be impacted to these vulnerabilities.